### PR TITLE
Fix packet error, connecting extended 4.7.2 client

### DIFF
--- a/src/client/c-cmd.c
+++ b/src/client/c-cmd.c
@@ -3428,7 +3428,7 @@ void cmd_check_misc(void) {
 				/* allow specifying minlev? */
 				if (is_newer_than(&server_version, 4, 5, 4, 0, 0, 0)) {
 					second = c_get_quantity("Specify minimum level? (ESC for none): ", 0);
-					if (is_newer_than(&server_version, 4, 7, 2, 0, 0, 0))
+					if (is_atleast(&server_version, 4, 7, 3, 0, 0, 0))
 						Send_special_line(SPECIAL_FILE_MONSTER, choice + second * 100000 + (uniques ? 100000000 : 0));
 					else
 						Send_special_line(SPECIAL_FILE_MONSTER, choice + second * 100000);

--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -3185,7 +3185,7 @@ int Receive_store(void) {
 	byte	attr;
 	s16b	wgt, num, pval;
 
-	if (is_newer_than(&server_version, 4, 7, 2, 0, 0, 0)) {
+	if (is_atleast(&server_version, 4, 7, 3, 0, 0, 0)) {
 		if ((n = Packet_scanf(&rbuf, "%c%c%c%hd%hd%d%S%c%c%hd%s", &ch, &pos, &attr, &wgt, &num, &price, name, &tval, &sval, &pval, &powers)) <= 0)
 			return n;
 	} else if (is_newer_than(&server_version, 4, 4, 7, 0, 0, 0)) {

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -9016,3 +9016,6 @@ extern int PlayerUID;
 /* Chance for weapons / digging tools / p_ptr->impact to cause an earthquake, even if all case-specific rolls already succeeded.
    Unified value for digging and fighting here, as characters could use their weapons as digging tools just as well. */
 #define QUAKE_CHANCE	50
+
+/* More readable than !is_older_than (in common/common.c) */
+#define is_atleast(vtptr, ma, mi, pa, ex, br, bu) (!is_older_than(vtptr, ma, mi, pa, ex, br, bu))

--- a/src/server/nserver.c
+++ b/src/server/nserver.c
@@ -2562,7 +2562,7 @@ static void sync_options(int Ind, bool *options) {
 		if (!p_ptr->mute_when_idle && p_ptr->muted_when_idle) Send_idle(Ind, FALSE);
 	}
 
-	if (!is_older_than(&p_ptr->version, 4, 7, 2, 0, 0, 1)) p_ptr->find_ignore_montraps = options[130];
+	if (is_atleast(&p_ptr->version, 4, 7, 3, 0, 0, 0)) p_ptr->find_ignore_montraps = options[130];
 	else p_ptr->find_ignore_montraps = TRUE;
     }
 }
@@ -7146,7 +7146,7 @@ int Send_store(int Ind, char pos, byte attr, int wgt, int number, int price, cpt
 #ifdef MINDLINK_STORE
 	if (get_esp_link(Ind, LINKF_VIEW, &p_ptr2)) {
 		connp2 = Conn[p_ptr2->conn];
-		if (is_newer_than(&p_ptr2->version, 4, 7, 2, 0, 0, 0))
+		if (is_atleast(&p_ptr2->version, 4, 7, 3, 0, 0, 0))
 			Packet_printf(&connp2->c, "%c%c%c%hd%hd%d%S%c%c%hd%s", PKT_STORE, pos, attr, wgt, number, price, name, tval, sval, pval, "");
 		else if (is_newer_than(&p_ptr2->version, 4, 4, 7, 0, 0, 0))
 			Packet_printf(&connp2->c, "%c%c%c%hd%hd%d%S%c%c%hd", PKT_STORE, pos, attr, wgt, number, price, name, tval, sval, pval);
@@ -7155,7 +7155,7 @@ int Send_store(int Ind, char pos, byte attr, int wgt, int number, int price, cpt
 	}
 #endif
 
-	if (is_newer_than(&Players[Ind]->version, 4, 7, 2, 0, 0, 0))
+	if (is_atleast(&Players[Ind]->version, 4, 7, 3, 0, 0, 0))
 		return Packet_printf(&connp->c, "%c%c%c%hd%hd%d%S%c%c%hd%s", PKT_STORE, pos, attr, wgt, number, price, name, tval, sval, pval, powers);
 	else if (is_newer_than(&Players[Ind]->version, 4, 4, 7, 0, 0, 0))
 		return Packet_printf(&connp->c, "%c%c%c%hd%hd%d%S%c%c%hd", PKT_STORE, pos, attr, wgt, number, price, name, tval, sval, pval);

--- a/src/server/xtra1.c
+++ b/src/server/xtra1.c
@@ -2601,8 +2601,8 @@ void calc_body_spells(int Ind) {
 	p_ptr->innate_spells[1] = r_ptr->flags5 & RF5_PLAYER_SPELLS;
 	p_ptr->innate_spells[2] = r_ptr->flags6 & RF6_PLAYER_SPELLS;
 	p_ptr->innate_spells[3] = r_ptr->flags0 & RF0_PLAYER_SPELLS;
-	if (is_older_than(&p_ptr->version, 4, 7, 2, 0, 0, 1)) Send_spell_info(Ind, 0, 0, 0, "");
-	else Send_powers_info(Ind);
+	if (is_atleast(&p_ptr->version, 4, 7, 3, 0, 0, 0)) Send_powers_info(Ind);
+	else Send_spell_info(Ind, 0, 0, 0, "");
 }
 
 #if 0	// moved to defines.h
@@ -3284,8 +3284,8 @@ void calc_boni(int Ind) {
 		p_ptr->innate_spells[2] = 0x0;
 		p_ptr->innate_spells[3] = 0x0;
 		if (!suppress_boni && logged_in) {
-			if (is_older_than(&p_ptr->version, 4, 7, 2, 0, 0, 1)) Send_spell_info(Ind, 0, 0, 0, "");
-			else Send_powers_info(Ind);
+			if (is_atleast(&p_ptr->version, 4, 7, 3, 0, 0, 0)) Send_powers_info(Ind);
+			else Send_spell_info(Ind, 0, 0, 0, "");
 		}
 
 		/* Start with "normal" speed */


### PR DESCRIPTION
When connecting with an client with versions between 4.7.2 and 4.7.3,
server should handle the communication, as if it was a 4.7.2 client.

Also the 4.7.3 client should not check if server is 'newer' than 4.7.2, but if
server is 'newer or equal' (or 'not older') than 4.7.3, to allow possible
4.7.2 server extensions.