### PR TITLE
Improve client/server version check readability

### DIFF
--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -2063,7 +2063,7 @@ int Receive_char_info(void) {
 	race = class = trait = sex = mode = 0;
 	lives = -1;
 
-	if (!is_older_than(&server_version, 4, 7, 3, 0, 0, 0)) {
+	if (is_atleast(&server_version, 4, 7, 3, 0, 0, 0)) {
 		if ((n = Packet_scanf(&rbuf, "%c%hd%hd%hd%hd%hd%hd%s", &ch, &race, &class, &trait, &sex, &mode, &lives, cname)) <= 0) return n;
 	} else if (is_newer_than(&server_version, 4, 5, 2, 0, 0, 0)) {
 		if ((n = Packet_scanf(&rbuf, "%c%hd%hd%hd%hd%hd%s", &ch, &race, &class, &trait, &sex, &mode, cname)) <= 0) return n;
@@ -2378,7 +2378,7 @@ int Receive_char(void) {
 		}
 	}
 #else
-	if (!is_older_than(&server_version, 4, 7, 3, 0, 0, 0)) {
+	if (is_atleast(&server_version, 4, 7, 3, 0, 0, 0)) {
 		if ((a & TERM_HILITE_PLAYER)) {
 			a &= ~TERM_HILITE_PLAYER;
 			is_us = TRUE;

--- a/src/server/cave.c
+++ b/src/server/cave.c
@@ -2136,7 +2136,7 @@ static byte player_color(int Ind) {
 	/* NOTE: For the player looking at himself, this is done in lite_spot(),
 	         which is called from set_tim_manashield().  */
 #ifdef EXTENDED_TERM_COLOURS
-	if (!is_older_than(&p_ptr->version, 4, 5, 1, 2, 0, 0)) {
+	if (is_atleast(&p_ptr->version, 4, 5, 1, 2, 0, 0)) {
 		if (p_ptr->tim_manashield > 15) return TERM_SHIELDM;
 		else if (p_ptr->tim_manashield) return TERM_NEXU;
 		if (p_ptr->nimbus > 15) return spell_color(p_ptr->nimbus_t);
@@ -3961,7 +3961,7 @@ void lite_spot(int Ind, int y, int x) {
 					if (is_us && is_newer_than(&p_ptr->version, 4, 5, 4, 0, 0, 0)) c |= 0x80;
 				}
 #else
-				if (is_us && p_ptr->hilite_player && !is_older_than(&p_ptr->version, 4, 7, 3, 0, 0, 0)) a |= 0x80;
+				if (is_us && p_ptr->hilite_player && is_atleast(&p_ptr->version, 4, 7, 3, 0, 0, 0)) a |= 0x80;
 #endif
 
 				/* Tell client to redraw this grid */
@@ -4770,7 +4770,7 @@ static void wild_display_map(int Ind, char mode) {
 	}
 
 	/* Indicate 'finished sending', so the client can add some extra info to the map */
-	if (!is_older_than(&p_ptr->version, 4, 7, 1, 2, 0, 0)) Send_mini_map(Ind, -1, 0, 0);
+	if (is_atleast(&p_ptr->version, 4, 7, 1, 2, 0, 0)) Send_mini_map(Ind, -1, 0, 0);
 
 	/* Restore lighting effects */
 	p_ptr->floor_lighting = old_floor_lighting;

--- a/src/server/nserver.c
+++ b/src/server/nserver.c
@@ -2532,7 +2532,7 @@ static void sync_options(int Ind, bool *options) {
 		}
 	}
 
-	if (!is_older_than(&p_ptr->version, 4, 7, 1, 0, 0, 0)) {
+	if (is_atleast(&p_ptr->version, 4, 7, 1, 0, 0, 0)) {
 		p_ptr->last_words = options[117]; //it's back!
 		p_ptr->disturb_see = options[118];
 	} else {
@@ -5816,12 +5816,12 @@ int Send_char_info(int Ind, int race, int class, int trait, int sex, int mode, i
 #endif
 
 	/* Hack: Transmitted 'mode' is int, not char, so we can stuff this in */
-	if (!is_older_than(&Players[Ind]->version, 4, 7, 1, 1, 0, 0) && Players[Ind]->fruit_bat == 1) mode |= MODE_FRUIT_BAT;
+	if (is_atleast(&Players[Ind]->version, 4, 7, 1, 1, 0, 0) && Players[Ind]->fruit_bat == 1) mode |= MODE_FRUIT_BAT;
 
 	if (Players[Ind]->esp_link_flags & LINKF_VIEW_DEDICATED) return(0);
 	if (get_esp_link(Ind, LINKF_VIEW, &p_ptr2)) {
 		connp2 = Conn[p_ptr2->conn];
-		if (!is_older_than(&connp2->version, 4, 7, 3, 0, 0, 0)) {
+		if (is_atleast(&connp2->version, 4, 7, 3, 0, 0, 0)) {
 			Packet_printf(&connp2->c, "%c%hd%hd%hd%hd%hd%hd%s", PKT_CHAR_INFO, race, class, trait, sex, mode, lives, name);
 		} else if (is_newer_than(&connp2->version, 4, 5, 2, 0, 0, 0)) {
 			Packet_printf(&connp2->c, "%c%hd%hd%hd%hd%hd%s", PKT_CHAR_INFO, race, class, trait, sex, mode, name);
@@ -5839,7 +5839,7 @@ int Send_char_info(int Ind, int race, int class, int trait, int sex, int mode, i
 		return 0;
 	}
 
-	if (!is_older_than(&connp->version, 4, 7, 3, 0, 0, 0)) {
+	if (is_atleast(&connp->version, 4, 7, 3, 0, 0, 0)) {
 		return Packet_printf(&connp->c, "%c%hd%hd%hd%hd%hd%hd%s", PKT_CHAR_INFO, race, class, trait, sex, mode, lives, name);
 	} else if (is_newer_than(&connp->version, 4, 5, 2, 0, 0, 0)) {
 		return Packet_printf(&connp->c, "%c%hd%hd%hd%hd%hd%s", PKT_CHAR_INFO, race, class, trait, sex, mode, name);
@@ -6549,7 +6549,7 @@ int Send_bpr(int Ind, byte bpr, byte attr) {
 	if (Players[Ind]->esp_link_flags & LINKF_VIEW_DEDICATED) return(0);
 	if ((Ind2 = get_esp_link(Ind, LINKF_VIEW, &p_ptr2))) {
 		connp2 = Conn[p_ptr2->conn];
-		if (bpr != 255 || !is_older_than(&Players[Ind2]->version, 4, 6, 1, 2, 0, 1))
+		if (bpr != 255 || is_atleast(&Players[Ind2]->version, 4, 6, 1, 2, 0, 1))
 			Packet_printf(&connp2->c, "%c%c%c", PKT_BPR, bpr, attr);
 	}
 

--- a/src/server/xtra1.c
+++ b/src/server/xtra1.c
@@ -434,7 +434,7 @@ static void prt_speed(int Ind) {
 	int i = p_ptr->pspeed;
 
 	/* Mark 'temporary' speed effects */
-	if (!is_older_than(&p_ptr->version, 4, 7, 3, 0, 0, 0) &&
+	if (is_atleast(&p_ptr->version, 4, 7, 3, 0, 0, 0) &&
 	    p_ptr->fast && i >= 110)
 		i |= 0x100;
 


### PR DESCRIPTION
For better readability, the usage of ```is_atleast``` is preferred before ```!is_older_than``` (as discussed in #3 ).

This PR fixes latest @CBlueGH additions and some older usage. 