### PR TITLE
Fix for catalogue:/etc/X11/fontpath.d font path

### DIFF
--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -7233,7 +7233,7 @@ static void do_cmd_options_fonts(void) {
   #ifdef USE_X11 /* Linux/OSX use at least the basic system fonts (/usr/share/fonts/misc) - C. Blue */
 	/* Get bitmap font folder ('misc') and scan fonts.alias in it for basic bitmap fonts:
 	   'cat `xset q | grep -o "[/a-z]*misc"`/fonts.alias | grep -o "^[0-9][0-9]*x[0-9]*\(bold\)\? " | grep -o "[^ ]*"' <- note the trailing space! */
-	j = system("cat `xset q | grep -o \"[/a-z]*misc\"`/fonts.alias | grep -o \"^[0-9][0-9]*x[0-9]*\\(bold\\)\\? \" | grep -o \"[^ ]*\" > /tmp/tomenet-fonts.tmp");
+	j = system("cat `xset q | grep -o \"[/a-z]*misc\" || ls -l /etc/X11/fontpath.d/ | grep -Po \"[a-zA-Z0-9/]{1,}misc\"`/fonts.alias | grep -o \"^[0-9][0-9]*x[0-9]*\\(bold\\)\\? \" | grep -o \"[^ ]*\" > /tmp/tomenet-fonts.tmp");
 	fff = fopen("/tmp/tomenet-fonts.tmp", "r");
 	if (fff) {
 		while (fonts < MAX_FONTS) {


### PR DESCRIPTION
Fedora have  location for Font Path in xset q used for changing fonts in X11 client

```
Font Path:
  catalogue:/etc/X11/fontpath.d,built-ins
```

This workound probably will not work on non GNU grep… because of -P option and otherwise I don't know how to grep only path using grep. Could be achieved using grep with awk… But shouldn't brake anything as far I know, because of using OR in shell command.