### PR TITLE
*ID* shop service: show only not ID'ed items in character inventory

### DIFF
--- a/lib/game/ba_info.txt
+++ b/lib/game/ba_info.txt
@@ -87,7 +87,7 @@ I:13:0:r:0
 
 N:14:Research item
 C:3000:2500:2000
-I:1:0:a:2
+I:1:0:a:10
 
 N:15:Town history
 C:0:0:0
@@ -218,12 +218,12 @@ I:42:0:v:0
 #for The Mirror
 N:44:Research item
 C:3500:3500:3500
-I:1:0:a:2
+I:1:0:a:10
 
 #for library in gondol
 N:45:Research item
 C:5000:5000:5000
-I:1:0:a:2
+I:1:0:a:10
 
 #for Star-Dome
 N:46:Identify possessions

--- a/src/client/c-store.c
+++ b/src/client/c-store.c
@@ -455,6 +455,7 @@ static void store_do_command(int num, bool one) {
 	char            out_val[160];
 	/* BIG_MAP leads to big shops */
 	int entries = (screen_hgt == MAX_SCREEN_HGT) ? 26 : 12;
+	int get_item_mode = 0;
 
 	i = amt = gold = item = item2 = 0;
 
@@ -501,7 +502,17 @@ static void store_do_command(int num, bool one) {
 	}
 
 	if (c_store.flags[num] & BACT_F_INVENTORY) {
-		if (!c_get_item(&item, "Which item? ", (USE_EQUIP | USE_INVEN)))
+		get_item_mode = (USE_EQUIP | USE_INVEN);
+
+		if (c_store.flags[num] & BACT_F_ID_INVENTORY) {
+			get_item_extra_hook = get_item_hook_find_obj;
+			item_tester_hook = item_tester_hook_starid;
+			get_item_hook_find_obj_what = "Which item? "; /* Seems it's not needed, but just in case */
+
+			get_item_mode |= USE_EXTRA;
+		}
+
+		if (!c_get_item(&item, "Which item? ", get_item_mode))
 			return;
 	}
 

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -8500,6 +8500,7 @@ extern int PlayerUID;
 #define BACT_F_STORE_ITEM	0x01
 #define BACT_F_INVENTORY	0x02
 #define BACT_F_GOLD		0x04
+#define BACT_F_ID_INVENTORY 	0x08
 #define BACT_F_HARDCODE		0x80
 
 /* Town types, not to be confused with town default indices */


### PR DESCRIPTION
Added new flag for buildings actions to show only not ID'ed items in player inventory, modified client to support new flag.

Tested:
- [x] new client + new server
- [x] old client + new server
- [x] new client + old server

