### PR TITLE
Fix server crashing when mapping a big number to character

### DIFF
--- a/src/client/c-init.c
+++ b/src/client/c-init.c
@@ -3792,7 +3792,7 @@ void client_init(char *argv1, bool skip) {
 	}
 
 #ifdef USE_GRAPHICS
-	/* If server is older than 5.0.0, then it doesn't support 32bit characters, so turn off graphics if turned on. */
+	/* If server is older than 4.8.1, then it doesn't support 32bit characters, so turn off graphics if turned on. */
 	if (use_graphics && is_older_than(&server_version, 4, 8, 1, 0, 0, 0)) {
 		plog_fmt("Server doesn't support graphics. Graphics turned off.");
 		use_graphics = FALSE;

--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -1397,7 +1397,7 @@ int Net_start(int sex, int race, int class) {
 
 	/* Send the "unknown" redefinitions */
 	for (i = 0; i < TV_MAX; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.u_attr[i], Client_setup.u_char[i]);
 		} else {
@@ -1414,7 +1414,7 @@ int Net_start(int sex, int race, int class) {
 	else limit = MAX_F_IDX_COMPAT;
 
 	for (i = 0; i < limit; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.f_attr[i], Client_setup.f_char[i]);
 		} else {
@@ -1431,7 +1431,7 @@ int Net_start(int sex, int race, int class) {
 	else limit = MAX_K_IDX_COMPAT;
 
 	for (i = 0; i < limit; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.k_attr[i], Client_setup.k_char[i]);
 		} else {
@@ -1448,7 +1448,7 @@ int Net_start(int sex, int race, int class) {
 	else limit = MAX_R_IDX_COMPAT;
 
 	for (i = 0; i < limit; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.r_attr[i], Client_setup.r_char[i]);
 		} else {
@@ -2583,7 +2583,7 @@ int Receive_char(void) {
 	char32_t	c = 0; /* Needs to be initialized for proper packet read. */
 	bool is_us = FALSE;
 
-	/* 5.0.0 and newer servers communicate using 32bit character size. */
+	/* 4.8.1 and newer servers communicate using 32bit character size. */
 	if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 		/* Transfer only minimum number of bytes needed, according to client setup.*/
 		char *pc = (char *)&c;
@@ -3450,7 +3450,7 @@ int Receive_line_info(void) {
 	for (x = 0; x < 80; x++) {
 		c = 0; /* Needs to be reset for proper packet read. */
 		/* Read the char/attr pair */
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			if ((n = Packet_scanf(&rbuf, "%u%c", &c, &a)) <= 0) {
 				if (n == 0) goto rollback;
@@ -3599,7 +3599,7 @@ int Receive_mini_map_pos(void) {
 	short int x, y;
 	byte	a;
 
-	/* 5.0.0 and newer servers communicate using 32bit character size. */
+	/* 4.8.1 and newer servers communicate using 32bit character size. */
 	if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 		if ((n = Packet_scanf(&rbuf, "%c%hd%hd%c%u", &ch, &x, &y, &a, &c)) <= 0) return n;
 	} else {
@@ -4058,7 +4058,7 @@ int Receive_boni_col(void) {
 	char color;
 	char32_t symbol = 0; /* Needs to be reset for proper packet read. */
 
-	/* 5.0.0 and newer servers communicate using 32bit character size. */
+	/* 4.8.1 and newer servers communicate using 32bit character size. */
 	if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 		if ((n = Packet_scanf(&rbuf, "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%u", &ch, //1+22+16+5 bytes in total
 						&i, &spd, &slth, &srch, &infr, &lite, &dig, &blow, &crit, &shot,
@@ -6471,7 +6471,7 @@ int Send_client_setup(void) {
 
 	/* Send the "unknown" redefinitions */
 	for (i = 0; i < TV_MAX; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.u_attr[i], Client_setup.u_char[i]);
 		} else {
@@ -6485,7 +6485,7 @@ int Send_client_setup(void) {
 
 	/* Send the "feature" redefinitions */
 	for (i = 0; i < MAX_F_IDX; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.f_attr[i], Client_setup.f_char[i]);
 		} else {
@@ -6499,7 +6499,7 @@ int Send_client_setup(void) {
 
 	/* Send the "object" redefinitions */
 	for (i = 0; i < MAX_K_IDX; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.k_attr[i], Client_setup.k_char[i]);
 		} else {
@@ -6513,7 +6513,7 @@ int Send_client_setup(void) {
 
 	/* Send the "monster" redefinitions */
 	for (i = 0; i < MAX_R_IDX; i++) {
-		/* 5.0.0 and newer servers communicate using 32bit character size. */
+		/* 4.8.1 and newer servers communicate using 32bit character size. */
 		if (is_atleast(&server_version, 4, 8, 1, 0, 0, 0)) {
 			Packet_printf(&wbuf, "%c%u", Client_setup.r_attr[i], Client_setup.r_char[i]);
 		} else {

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -2356,6 +2356,14 @@ struct boni_col {
 	byte color; char32_t symbol;
 };
 
+/* Dictionary for storing character redefinitions mapping information. */
+typedef struct u32b_char_dict_t u32b_char_dict_t;
+struct u32b_char_dict_t {
+	struct u32b_char_dict_t *next;
+	uint32_t key;
+	char value;
+};
+
 /*
  * Most of the "player" information goes here.
  *
@@ -2590,12 +2598,12 @@ struct player_type {
 	byte f_attr_solid[MAX_F_IDX];
 	char32_t f_char[MAX_F_IDX];
 	char32_t f_char_solid[MAX_F_IDX];
-	char32_t f_char_mod[256];
+	u32b_char_dict_t *f_char_mod;
 	byte k_attr[MAX_K_IDX];
 	char32_t k_char[MAX_K_IDX];
 	byte r_attr[MAX_R_IDX];
 	char32_t r_char[MAX_R_IDX];
-	char32_t r_char_mod[256];
+	u32b_char_dict_t *r_char_mod;
 
 	bool carry_query_flag;
 	bool use_old_target;
@@ -4212,12 +4220,4 @@ struct hash_entry {
 	byte order;			/* custom order in account screen overview */
 
 	struct hash_entry *next;	/* Next entry in the chain */
-};
-
-/* Dictionary for storing character redefinitions mapping information. */
-typedef struct u32b_char_dict_t u32b_char_dict_t;
-struct u32b_char_dict_t {
-	struct u32b_char_dict_t *next;
-	uint32_t key;
-	char value;
 };

--- a/src/server/externs.h
+++ b/src/server/externs.h
@@ -38,6 +38,10 @@ extern char *roman_suffix(char* cname);
 #ifdef ENABLE_SUBINVEN
 //extern int get_subinven_size(int sval);
 #endif
+extern struct u32b_char_dict_t *u32b_char_dict_set(struct u32b_char_dict_t *start, uint32_t key, char value);
+extern char *u32b_char_dict_get(struct u32b_char_dict_t *start, uint32_t key);
+extern struct u32b_char_dict_t *u32b_char_dict_unset(struct u32b_char_dict_t *start, uint32_t key);
+extern struct u32b_char_dict_t *u32b_char_dict_free(struct u32b_char_dict_t *start);
 
 /* common/files.c */
 extern int local_file_init(int ind, unsigned short fnum, char *fname);

--- a/src/server/nserver.c
+++ b/src/server/nserver.c
@@ -1535,6 +1535,10 @@ static void Delete_player(int Ind) {
 			C_FREE(p_ptr->inventory, INVEN_TOTAL, object_type);
 		if (p_ptr->inventory_copy)
 			C_FREE(p_ptr->inventory_copy, INVEN_TOTAL, object_type);
+		if (p_ptr->f_char_mod != NULL)
+			p_ptr->f_char_mod = u32b_char_dict_free(p_ptr->f_char_mod);
+		if (p_ptr->r_char_mod != NULL)
+			p_ptr->r_char_mod = u32b_char_dict_free(p_ptr->r_char_mod);
 
 		KILL(Players[NumPlayers], player_type);
 	}
@@ -1632,8 +1636,6 @@ bool Destroy_connection(int ind, char *reason_orig) {
 			p_ptr->solo_reking_laston = now;
 		}
 #endif
-		if (p_ptr->f_char_mod != NULL) p_ptr->f_char_mod = u32b_char_dict_free(p_ptr->f_char_mod);
-		if (p_ptr->r_char_mod != NULL) p_ptr->r_char_mod = u32b_char_dict_free(p_ptr->r_char_mod);
 
 		s_printf("%s: Goodbye %s(%s)=%s@%s (\"%s\") (Ind=%d,ind=%d;wpos=%d,%d,%d;xy=%d,%d)\n",
 		    showtime(),

--- a/src/server/nserver.c
+++ b/src/server/nserver.c
@@ -5108,7 +5108,7 @@ static int Receive_play(int ind) {
 		/* Read the "unknown" char/attrs */
 		for (i = 0; i < TV_MAX; i++) {
 			connp->Client_setup.u_char[i] = 0; /* Needs to be initialized for proper packet read. */
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0))
 				n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.u_attr[i], &connp->Client_setup.u_char[i]);
 			else
@@ -5134,7 +5134,7 @@ static int Receive_play(int ind) {
 
 		for (i = 0; i < limit; i++) {
 			connp->Client_setup.f_char[i] = 0; /* Needs to be initialized for proper packet read. */
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0))
 				n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.f_attr[i], &connp->Client_setup.f_char[i]);
 			else
@@ -5162,7 +5162,7 @@ static int Receive_play(int ind) {
 		limit = MAX_K_IDX_COMPAT;
 		for (i = 0; i < limit; i++) {
 			connp->Client_setup.k_char[i] = 0; /* Needs to be initialized for proper packet read. */
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0))
 				n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.k_attr[i], &connp->Client_setup.k_char[i]);
 			else
@@ -5190,7 +5190,7 @@ static int Receive_play(int ind) {
 		limit = MAX_R_IDX_COMPAT;
 		for (i = 0; i < limit; i++) {
 			connp->Client_setup.r_char[i] = 0; /* Needs to be initialized for proper packet read. */
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0))
 				n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.r_attr[i], &connp->Client_setup.r_char[i]);
 			else
@@ -6838,7 +6838,7 @@ int Send_char(int Ind, int x, int y, byte a, char32_t c) {
 			if (NULL != (unm_c_ptr = u32b_char_dict_get(p_ptr->r_char_mod, unm_c_idx))) c2 = (char32_t)*unm_c_ptr;
 			else if (NULL != (unm_c_ptr = u32b_char_dict_get(p_ptr->f_char_mod, unm_c_idx))) c2 = (char32_t)*unm_c_ptr;
 
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 				/* Transfer only the relevant bytes, according to client setup.*/
 				char * pc = (char *)&c2;
@@ -6860,7 +6860,7 @@ int Send_char(int Ind, int x, int y, byte a, char32_t c) {
 		}
 	}
 
-	/* 5.0.0 and newer clients use 32bit character size. */
+	/* 4.8.1 and newer clients use 32bit character size. */
 	if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 		/* Transfer only the relevant bytes, according to client setup.*/
 		char * pc = (char *)&c;
@@ -7126,7 +7126,7 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 
 		/* RLE if there at least 2 similar grids in a row */
 		if (n >= 2) {
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 				Packet_printf(&connp->c, "%u%c%c%c", c, TERM_RESERVED_RLE, a, n);
 			}
@@ -7147,7 +7147,7 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 				else if (NULL != (unm_c_ptr = u32b_char_dict_get(p_ptr->f_char_mod, unm_c_idx))) cu = (char32_t)*unm_c_ptr;
 				else cu = c;
 
-				/* 5.0.0 and newer clients use 32bit character size. */
+				/* 4.8.1 and newer clients use 32bit character size. */
 				if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 						Packet_printf(&connp2->c, "%u%c%c%c", cu, TERM_RESERVED_RLE, a, n);
 				}
@@ -7171,7 +7171,7 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 			} else {
 				if (a == TERM_RESERVED_RLE) {
 					/* Use RLE format as an escape sequence for 0xFF as attr */
-					/* 5.0.0 and newer clients use 32bit character size. */
+					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 						Packet_printf(&connp->c, "%u%c%c%c", c, TERM_RESERVED_RLE, a, 1);
 					} else {
@@ -7179,7 +7179,7 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 					}
 				} else {
 					/* Normal output */
-					/* 5.0.0 and newer clients use 32bit character size. */
+					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 						Packet_printf(&connp->c, "%u%c", c, a);
 					} else {
@@ -7202,7 +7202,7 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 				} else {
 					if (a == TERM_RESERVED_RLE) {
 						/* Use RLE format as an escape sequence for 0xFF as attr */
-						/* 5.0.0 and newer clients use 32bit character size. */
+						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 							Packet_printf(&connp2->c, "%u%c%c%c", cu, TERM_RESERVED_RLE, a, 1);
 						} else {
@@ -7210,7 +7210,7 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 						}
 					} else {
 						/* Normal output */
-						/* 5.0.0 and newer clients use 32bit character size. */
+						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 							Packet_printf(&connp2->c, "%u%c", cu, a);
 						} else {
@@ -7303,7 +7303,7 @@ int Send_line_info_forward(int Ind, int Ind_src, int y) {
 
 		/* RLE if there at least 2 similar grids in a row */
 		if (n >= 2) {
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 				Packet_printf(&connp->c, "%u%c%c%c", c, TERM_RESERVED_RLE, a, n);
 			}
@@ -7326,7 +7326,7 @@ int Send_line_info_forward(int Ind, int Ind_src, int y) {
 			} else {
 				if (a == TERM_RESERVED_RLE) {
 					/* Use RLE format as an escape sequence for 0xFF as attr */
-					/* 5.0.0 and newer clients use 32bit character size. */
+					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 						Packet_printf(&connp->c, "%u%c%c%c", c, TERM_RESERVED_RLE, a, 1);
 					} else {
@@ -7334,7 +7334,7 @@ int Send_line_info_forward(int Ind, int Ind_src, int y) {
 					}
 				} else {
 					/* Normal output */
-					/* 5.0.0 and newer clients use 32bit character size. */
+					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 						Packet_printf(&connp->c, "%u%c", c, a);
 					} else {
@@ -7401,7 +7401,7 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 
 		/* RLE if there at least 2 similar grids in a row */
 		if (n >= 2) {
-			/* 5.0.0 and newer clients use 32bit character size. */
+			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 				Packet_printf(&connp->c, "%u%c%c%c", c, 0xFF, a, n);
 			}
@@ -7415,7 +7415,7 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 			}
 
 			if (Ind2) {
-				/* 5.0.0 and newer clients use 32bit character size. */
+				/* 4.8.1 and newer clients use 32bit character size. */
 				if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 					Packet_printf(&connp2->c, "%u%c%c%c", c, TERM_RESERVED_RLE, a, n);
 				}
@@ -7439,7 +7439,7 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 			} else {
 				if (a == TERM_RESERVED_RLE) {
 					/* Use RLE format as an escape sequence for 0xFF as attr */
-					/* 5.0.0 and newer clients use 32bit character size. */
+					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 						Packet_printf(&connp->c, "%u%c%c%c", c, TERM_RESERVED_RLE, a, 1);
 					} else {
@@ -7447,7 +7447,7 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 					}
 				} else {
 					/* Normal output */
-					/* 5.0.0 and newer clients use 32bit character size. */
+					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 						Packet_printf(&connp->c, "%u%c", c, a);
 					} else {
@@ -7463,7 +7463,7 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 				} else {
 					if (a == TERM_RESERVED_RLE) {
 						/* Use RLE format as an escape sequence for 0xFF as attr */
-						/* 5.0.0 and newer clients use 32bit character size. */
+						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 							Packet_printf(&connp2->c, "%u%c%c%c", c, TERM_RESERVED_RLE, a, 1);
 						} else {
@@ -7471,7 +7471,7 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 						}
 					} else {
 						/* Normal output */
-						/* 5.0.0 and newer clients use 32bit character size. */
+						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 							Packet_printf(&connp2->c, "%u%c", c, a);
 						} else {
@@ -7514,7 +7514,7 @@ int Send_mini_map_pos(int Ind, int x, int y, byte a, char32_t c) {
 #endif
 
 	/* Packet header */
-	/* 5.0.0 and newer clients use 32bit character size. */
+	/* 4.8.1 and newer clients use 32bit character size. */
 	if (is_atleast(&p_ptr->version, 4, 8, 1, 0, 0, 0)) Packet_printf(&connp->c, "%c%hd%hd%c%u", PKT_MINI_MAP_POS, xs, ys, a, c);
 	else if (is_newer_than(&p_ptr->version, 4, 5, 5, 0, 0, 0)) Packet_printf(&connp->c, "%c%hd%hd%c%c", PKT_MINI_MAP_POS, xs, ys, a, (char)c);
 	//if (Ind2 && is_newer_than(&p_ptr2->version, 4, 5, 5, 0, 0, 0)) Packet_printf(&connp2->c, "%c%hd%hd%c%c", PKT_MINI_MAP_POS, xs, ys, a, c);
@@ -8185,7 +8185,7 @@ int Send_boni_col(int Ind, boni_col c) {
 	}
 
 	if (!is_newer_than(&connp->version, 4, 5, 3, 2, 0, 0)) return(-1);
-	/* 5.0.0 and newer clients use 32bit character size. */
+	/* 4.8.1 and newer clients use 32bit character size. */
 	if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 		return Packet_printf(&connp->c, "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%u", PKT_BONI_COL, //1+22+13+2 bytes in total
 				c.i, c.spd, c.slth, c.srch, c.infr, c.lite, c.dig, c.blow, c.crit, c.shot,
@@ -13619,7 +13619,7 @@ static int Receive_client_setup(int ind) {
 	/* Read the "unknown" char/attrs */
 	for (i = 0; i < TV_MAX; i++) {
 		connp->Client_setup.u_char[i] = 0; /* Needs to be initialized for proper packet read. */
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.u_attr[i], &connp->Client_setup.u_char[i]);
 		} else {
@@ -13639,7 +13639,7 @@ static int Receive_client_setup(int ind) {
 	/* Read the "feature" char/attrs */
 	for (i = 0; i < MAX_F_IDX; i++) {
 		connp->Client_setup.f_char[i] = 0; /* Needs to be initialized for proper packet read. */
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.f_attr[i], &connp->Client_setup.f_char[i]);
 		} else {
@@ -13659,7 +13659,7 @@ static int Receive_client_setup(int ind) {
 	/* Read the "object" char/attrs */
 	for (i = 0; i < MAX_K_IDX; i++) {
 		connp->Client_setup.k_char[i] = 0; /* Needs to be initialized for proper packet read. */
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.k_attr[i], &connp->Client_setup.k_char[i]);
 		} else {
@@ -13679,7 +13679,7 @@ static int Receive_client_setup(int ind) {
 	/* Read the "monster" char/attrs */
 	for (i = 0; i < MAX_R_IDX; i++) {
 		connp->Client_setup.r_char[i] = 0; /* Needs to be initialized for proper packet read. */
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.r_attr[i], &connp->Client_setup.r_char[i]);
 		} else {
@@ -13742,7 +13742,7 @@ static int Receive_client_setup_U(int ind) {
 		return -1;
 	}
 	for (i = begin; i < end; i++) {
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.u_attr[i], &connp->Client_setup.u_char[i]);
 		} else {
@@ -13795,7 +13795,7 @@ static int Receive_client_setup_F(int ind) {
 	}
 	for (i = begin; i < end; i++) {
 		connp->Client_setup.f_char[i] = 0; /* Needs to be initialized for proper packet read. */
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.f_attr[i], &connp->Client_setup.f_char[i]);
 		} else {
@@ -13848,7 +13848,7 @@ static int Receive_client_setup_K(int ind) {
 	}
 	for (i = begin; i < end; i++) {
 		connp->Client_setup.k_char[i] = 0; /* Needs to be initialized for proper packet read. */
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.k_attr[i], &connp->Client_setup.k_char[i]);
 		} else {
@@ -13901,7 +13901,7 @@ static int Receive_client_setup_R(int ind) {
 	}
 	for (i = begin; i < end; i++) {
 		connp->Client_setup.r_char[i] = 0; /* Needs to be initialized for proper packet read. */
-		/* 5.0.0 and newer clients use 32bit character size. */
+		/* 4.8.1 and newer clients use 32bit character size. */
 		if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 			n = Packet_scanf(&connp->r, "%c%u", &connp->Client_setup.r_attr[i], &connp->Client_setup.r_char[i]);
 		} else {


### PR DESCRIPTION
~~It's not fully tested yet, but~~ you told, that my old code is live, so I made this PR to fix the possible server crashes.
I experienced these crashes, when tested the dynamic byte transfer for character and set the MAX_FONT to high number (>255*200). I was because the [fr]_char_mod variable used for unmapping for map mind linking, used to be an array of 256 chars. Now the char can be a 32 number, so I had to change the array to a dictionary(linked list).

Edit:I also took liberty to change the 5.0.0 in comments to 4.8.1.
Edit: I just tested if it works for MAX_FONT with high values, so we had to transfer 3 or 4 bytes per character and it works. Hope I didn't introduced more errors.