### PR TITLE
Fix mind-linking packet errors?

### DIFF
--- a/src/server/nserver.c
+++ b/src/server/nserver.c
@@ -6844,14 +6844,17 @@ int Send_char(int Ind, int x, int y, byte a, char32_t c) {
 			if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
 				/* Transfer only the relevant bytes, according to client setup.*/
 				char * pc = (char *)&c2;
-				switch (connp->Client_setup.char_transfer_bytes) {
+				switch (connp2->Client_setup.char_transfer_bytes) {
 					case 0:
 					case 1:
 						Packet_printf(&connp2->c, "%c%c%c%c%c", PKT_CHAR, x, y, a, pc[0]);
+						break;
 					case 2:
 						Packet_printf(&connp2->c, "%c%c%c%c%c%c", PKT_CHAR, x, y, a, pc[1], pc[0]);
+						break;
 					case 3:
 						Packet_printf(&connp2->c, "%c%c%c%c%c%c%c", PKT_CHAR, x, y, a, pc[2], pc[1], pc[0]);
+						break;
 					case 4:
 					default:
 						Packet_printf(&connp2->c, "%c%c%c%c%u", PKT_CHAR, x, y, a, c2);


### PR DESCRIPTION
@CBlueGH said in #28 
> Hm, mindlink still causes packet error here, I just tried it on a local server, with client+server cleanly compiled from latest source, and source+target clients both using latest source, tested client mindlink linux->linux and windows->windows.

I think I've found the issue. I worked in golang before, there the cases in switch don't fall through by default. Forgot, that it is different here.

But I couldn't test. I tried to search in Guide, but I haven't figured out how to do that map mind linking. Please point me in the right direction (special race? name of spell?), how do I cast and test.

Also you can try to test too, but I really would like to know how to test, to be able to test the changes in #29 .

Thanks