### PR TITLE
Fix server crash when creating a PvP player on unvalidated account

### DIFF
--- a/src/server/birth.c
+++ b/src/server/birth.c
@@ -3471,6 +3471,7 @@ bool player_birth(int Ind, int conn, connection_t *connp) {
 		p_ptr->mode &= ~MODE_PVP;
 #else
 		Destroy_connection(conn, "Sorry, your account must be validated before you can choose 'PvP' mode.");
+		return FALSE;
 #endif
 	}
 


### PR DESCRIPTION
During my testing the server crashed when tried to create an PvP player and got rejected, because of invalidated account.

This helped not to crash the server.