### PR TITLE
Remove jezek debug prints and comments

### DIFF
--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -3449,7 +3449,6 @@ int Receive_line_info(void) {
 	last_line_y = y;
 #endif
 
-	printf("jezek - Receive_line_info: ch: %d, y: %d\n", ch, y);
 	for (x = 0; x < 80; x++) {
 		c = 0; /* Needs to be reset for proper packet read. */
 		/* Read the char/attr pair */

--- a/src/server/nserver.c
+++ b/src/server/nserver.c
@@ -2686,7 +2686,6 @@ static void set_player_font_definitions(int ind, int player) {
 #endif
 			{
 				p_ptr->f_char_mod = u32b_char_dict_set(p_ptr->f_char_mod, unm_c_idx, (char)f_info[i].z_char);
-				printf("jezek - seted %u:%hhu into f_char_mod\n", unm_c_idx, (char)f_info[i].z_char);
 			}
 		}
 
@@ -2824,7 +2823,6 @@ static void set_player_font_definitions(int ind, int player) {
 #endif
 			{
 				p_ptr->r_char_mod = u32b_char_dict_set(p_ptr->r_char_mod, unm_c_idx, (char)r_info[i].x_char);
-				printf("jezek - seted %u:%hhu into r_char_mod\n", unm_c_idx, (char)r_info[i].x_char);
 			}
 		}
 
@@ -6884,13 +6882,6 @@ int Send_char(int Ind, int x, int y, byte a, char32_t c) {
 
 	/* 4.8.1 and newer clients use 32bit character size. */
 	if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-		//TODO jezek - This test revealed, that the full screen is transferred somewhere else too, add the char_transfer_bytes logic there too.
-			//char32_t unm_c_idx = c;
-			//char *unm_c_ptr;
-			//if (NULL != (unm_c_ptr = u32b_char_dict_get(p_ptr->r_char_mod, unm_c_idx))) c = (char32_t)*unm_c_ptr;
-			//else if (NULL != (unm_c_ptr = u32b_char_dict_get(p_ptr->f_char_mod, unm_c_idx))) c = (char32_t)*unm_c_ptr;
-			//printf("unm_c_idx: %u, c: %u, unm_c_ptr: %u\n", unm_c_idx, c, unm_c_ptr);
-
 		/* Transfer only the relevant bytes, according to client setup.*/
 		char * pc = (char *)&c;
 		switch (connp->Client_setup.char_transfer_bytes) {
@@ -7115,7 +7106,6 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 		/* Start with count of 1 */
 		n = 1;
 
-		printf("jezek - Send_line_info(Ind: %d, y: %d, scr_only: %d)\n", Ind, y, scr_only);
 		/* Count repetitions of this grid */
 		while (x1 < MAX_WINDOW_WID) {
 #ifdef LOCATE_KEEPS_OVL
@@ -7157,13 +7147,10 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 			x1++;
 		}
 
-		printf("jezek - x1: %d, n: %d, c: %u, a: %hhu\n", x1, n, c, a);
 		/* RLE if there at least 2 similar grids in a row */
 		if (n >= 2) {
 			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-				//TODO jezek - Use function Packet_printf_dynamic(n, conn, "%dc%c", params...) or something like.
-				printf("jezek - 1.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 				/* Transfer only the relevant bytes, according to client setup.*/
 				char * pc = (char *)&c;
 				switch (connp->Client_setup.char_transfer_bytes) {
@@ -7201,7 +7188,6 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 
 				/* 4.8.1 and newer clients use 32bit character size. */
 				if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
-					printf("jezek - 1.connp2->Client_setup.char_transfer_bytes: %d, cu: %u\n", connp2->Client_setup.char_transfer_bytes, cu);
 					/* Transfer only the relevant bytes, according to client setup.*/
 					char * pcu = (char *)&cu;
 					switch (connp2->Client_setup.char_transfer_bytes) {
@@ -7242,7 +7228,6 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 					/* Use RLE format as an escape sequence for 0xFF as attr */
 					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-						printf("jezek - 2.1.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 						/* Transfer only the relevant bytes, according to client setup.*/
 						char * pc = (char *)&c;
 						switch (connp->Client_setup.char_transfer_bytes) {
@@ -7267,7 +7252,6 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 					/* Normal output */
 					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-						printf("jezek - 2.2.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 						/* Transfer only the relevant bytes, according to client setup.*/
 						char * pc = (char *)&c;
 						switch (connp->Client_setup.char_transfer_bytes) {
@@ -7307,7 +7291,6 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 						/* Use RLE format as an escape sequence for 0xFF as attr */
 						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
-							printf("jezek - 2.1.connp2->Client_setup.char_transfer_bytes: %d, cu: %u\n", connp2->Client_setup.char_transfer_bytes, cu);
 							/* Transfer only the relevant bytes, according to client setup.*/
 							char * pcu = (char *)&cu;
 							switch (connp2->Client_setup.char_transfer_bytes) {
@@ -7332,7 +7315,6 @@ int Send_line_info(int Ind, int y, bool scr_only) {
 						/* Normal output */
 						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
-							printf("jezek - 2.2.connp2->Client_setup.char_transfer_bytes: %d, cu: %u\n", connp2->Client_setup.char_transfer_bytes, cu);
 							/* Transfer only the relevant bytes, according to client setup.*/
 							char * pcu = (char *)&cu;
 							switch (connp2->Client_setup.char_transfer_bytes) {
@@ -7388,7 +7370,6 @@ int Send_line_info_forward(int Ind, int Ind_src, int y) {
 	/* Put a header on the packet */
 	Packet_printf(&connp->c, "%c%hd", PKT_LINE_INFO, y);
 
-	printf("jezek - Send_line_info_forward(Ind: %d, Ind_src: %d, y: %d)\n", Ind, Ind_src, y);
 	/* Each column */
 	for (x = 0; x < 80; x++) {
 		/* Obtain the char/attr pair */
@@ -7439,13 +7420,11 @@ int Send_line_info_forward(int Ind, int Ind_src, int y) {
 			else if (NULL != (unm_c_ptr = u32b_char_dict_get(p_ptr2->f_char_mod, unm_c_idx))) c1 = (char32_t)*unm_c_ptr;
 		}
 
-		printf("jezek - x1: %d, n: %d, c: %u, a: %hhu\n", x1, n, c, a);
 		/* RLE if there at least 2 similar grids in a row */
 		if (n >= 2) {
 			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
 				/* Transfer only the relevant bytes, according to client setup.*/
-				printf("jezek - 1.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 				char * pc = (char *)&c;
 				switch (connp->Client_setup.char_transfer_bytes) {
 					case 0:
@@ -7484,7 +7463,6 @@ int Send_line_info_forward(int Ind, int Ind_src, int y) {
 					/* Use RLE format as an escape sequence for 0xFF as attr */
 					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-						printf("jezek - 2.1.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 						/* Transfer only the relevant bytes, according to client setup.*/
 						char * pc = (char *)&c;
 						switch (connp->Client_setup.char_transfer_bytes) {
@@ -7509,7 +7487,6 @@ int Send_line_info_forward(int Ind, int Ind_src, int y) {
 					/* Normal output */
 					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-						printf("jezek - 2.2.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 						/* Transfer only the relevant bytes, according to client setup.*/
 						char * pc = (char *)&c;
 						switch (connp->Client_setup.char_transfer_bytes) {
@@ -7569,7 +7546,6 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 
 	/* Hack: Just a 'transmission finished' marker packet? */
 	if (y == -1) return 1;
-	printf("jezek - Send_mini_map(Ind: %d, y: %d)\n", Ind, y);
 
 	/* Each column */
 	for (x = 0; x < 80; x++) {
@@ -7590,12 +7566,10 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 			x1++;
 		}
 
-		printf("jezek - x1: %d, n: %d, c: %u, a: %hhu\n", x1, n, c, a);
 		/* RLE if there at least 2 similar grids in a row */
 		if (n >= 2) {
 			/* 4.8.1 and newer clients use 32bit character size. */
 			if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-				printf("jezek - 1.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 				/* Transfer only the relevant bytes, according to client setup.*/
 				char * pc = (char *)&c;
 				switch (connp->Client_setup.char_transfer_bytes) {
@@ -7624,10 +7598,8 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 			}
 
 			if (Ind2) {
-				//TODO jezek - don't need unmap?
 				/* 4.8.1 and newer clients use 32bit character size. */
 				if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
-					printf("jezek - 1.connp2->Client_setup.char_transfer_bytes: %d\n", connp2->Client_setup.char_transfer_bytes);
 					/* Transfer only the relevant bytes, according to client setup.*/
 					char * pc = (char *)&c;
 					switch (connp2->Client_setup.char_transfer_bytes) {
@@ -7668,7 +7640,6 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 					/* Use RLE format as an escape sequence for 0xFF as attr */
 					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-						printf("jezek - 2.1.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 						/* Transfer only the relevant bytes, according to client setup.*/
 						char * pc = (char *)&c;
 						switch (connp->Client_setup.char_transfer_bytes) {
@@ -7693,7 +7664,6 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 					/* Normal output */
 					/* 4.8.1 and newer clients use 32bit character size. */
 					if (is_atleast(&connp->version, 4, 8, 1, 0, 0, 0)) {
-						printf("jezek - 2.2.connp->Client_setup.char_transfer_bytes: %d\n", connp->Client_setup.char_transfer_bytes);
 						/* Transfer only the relevant bytes, according to client setup.*/
 						char * pc = (char *)&c;
 						switch (connp->Client_setup.char_transfer_bytes) {
@@ -7726,7 +7696,6 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 						/* Use RLE format as an escape sequence for 0xFF as attr */
 						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
-							printf("jezek - 2.1.connp2->Client_setup.char_transfer_bytes: %d\n", connp2->Client_setup.char_transfer_bytes);
 							/* Transfer only the relevant bytes, according to client setup.*/
 							char * pc = (char *)&c;
 							switch (connp2->Client_setup.char_transfer_bytes) {
@@ -7751,7 +7720,6 @@ int Send_mini_map(int Ind, int y, byte *sa, char32_t *sc) {
 						/* Normal output */
 						/* 4.8.1 and newer clients use 32bit character size. */
 						if (is_atleast(&connp2->version, 4, 8, 1, 0, 0, 0)) {
-							printf("jezek - 2.2.connp2->Client_setup.char_transfer_bytes: %d\n", connp2->Client_setup.char_transfer_bytes);
 							/* Transfer only the relevant bytes, according to client setup.*/
 							char * pc = (char *)&c;
 							switch (connp2->Client_setup.char_transfer_bytes) {
@@ -7808,7 +7776,6 @@ int Send_mini_map_pos(int Ind, int x, int y, byte a, char32_t c) {
 		connp2 = Conn[p_ptr2->conn];
 #endif
 
-	printf("jezek - Send_mini_map_pos(Ind: %d, x: %d, y: %d, a: %d, c: %u)\n", Ind, x, y, a, c);
 	/* Packet header */
 	/* 4.8.1 and newer clients use 32bit character size. */
 	if (is_atleast(&p_ptr->version, 4, 8, 1, 0, 0, 0)) Packet_printf(&connp->c, "%c%hd%hd%c%u", PKT_MINI_MAP_POS, xs, ys, a, c);


### PR DESCRIPTION
I've tested the code you accidentally merged with #29 and found out the code was alright. This removes all  the debug prints and comments.

I've also decided, that there are no more changes for the dynamic character transfer size needed. The only places where some 32 bit characters are transferred, that would benefit from the optimizations are in Send_minimap_pos and Send_boni_col function, which are rarely called, so there is no need for the changes. Or am I wrong?