### PR TITLE
X11 big map start bug fix

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -456,24 +456,10 @@ static void write_mangrc_aux(int t, cptr sec_name, FILE *cfg_file) {
 #endif
 		fputs(format("%s_Font\t%s\n", sec_name, font_name), cfg_file);
 	} else {
-		int hgt;
-		if (c_cfg.big_map || r > SCREEN_HGT + SCREEN_PAD_Y) {
-			/* only change height if we're currently running the default short height */
-			if (screen_hgt <= SCREEN_HGT)
-				hgt = SCREEN_PAD_Y + MAX_SCREEN_HGT;
-			/* also change it however if the main window was resized manually (ie by mouse dragging) */
-			else if (r != SCREEN_PAD_Y + screen_hgt)
-				hgt = r;
-			/* keep current, modified screen size */
-			else
-				hgt = SCREEN_PAD_Y + screen_hgt;
-		} else hgt = SCREEN_PAD_Y + SCREEN_HGT;
-		if (hgt > MAX_WINDOW_HGT) hgt = MAX_WINDOW_HGT;
-
 		/* one more tab, or formatting looks bad ;) */
 		fputs(format("%s_Font\t\t%s\n", sec_name, font_name), cfg_file);
-		/* only change to double-screen if we're not already in some kind of enlarged screen */
-		fputs(format("%s_Lines\t%d\n", sec_name, hgt), cfg_file);
+		/* If user has mouse-resized the main window, the dimensions get corrected back to valid dimensions, which are then reflected in screen_hgt variable. */
+		fputs(format("%s_Lines\t%d\n", sec_name, screen_hgt + SCREEN_PAD_Y), cfg_file);
 	}
 	fputs("\n", cfg_file);
 }
@@ -511,24 +497,8 @@ static void write_mangrc_aux_line(int t, cptr sec_name, char *buf_org) {
 	} else if (c && !strncmp(ter_name, "_Lines", 6)) {
 		if (t != 0)
 			sprintf(buf, "%s_Lines\t%d\n", sec_name, r);
-		else {
-			int hgt;
-			if (c_cfg.big_map || r > SCREEN_HGT + SCREEN_PAD_Y) {
-				/* only change height if we're currently running the default short height */
-				if (screen_hgt <= SCREEN_HGT)
-					hgt = SCREEN_PAD_Y + MAX_SCREEN_HGT;
-				/* also change it however if the main window was resized manually (ie by mouse dragging) */
-				else if (r != SCREEN_PAD_Y + screen_hgt)
-					hgt = r;
-				/* keep current, modified screen size */
-				else
-					hgt = SCREEN_PAD_Y + screen_hgt;
-			} else hgt = SCREEN_PAD_Y + SCREEN_HGT;
-			if (hgt > MAX_WINDOW_HGT) hgt = MAX_WINDOW_HGT;
-
-			/* only change to double-screen if we're not already in some kind of enlarged screen */
-			sprintf(buf, "%s_Lines\t%d\n", sec_name, hgt);
-		}
+		else
+			sprintf(buf, "%s_Lines\t%d\n", sec_name, screen_hgt + SCREEN_PAD_Y);
 	} else if (!strncmp(ter_name, "_Font", 5) && font_name[0] != '\0') {
 		if (t != 0)
 			sprintf(buf, "%s_Font\t%s\n", sec_name, font_name);

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -49,16 +49,11 @@ static void read_mangrc_aux(int t, cptr sec_name) {
 
 	if ((val = strstr(sec_name, "_Columns"))) {
 		term_prefs[t].columns = atoi(val + 8);
-		if (!term_prefs[t].columns) term_prefs[t].columns = 80;
-		if (t == 0) {
-			if (term_prefs[t].columns != 80) term_prefs[t].columns = 80;
-			screen_wid = term_prefs[0].columns - SCREEN_PAD_X;
-		}
+		if (!term_prefs[t].columns) term_prefs[t].columns = DEFAULT_TERM_WID;
 	}
 	if ((val = strstr(sec_name, "_Lines"))) {
 		term_prefs[t].lines = atoi(val + 6);
-		if (!term_prefs[t].lines) term_prefs[t].lines = 24;
-		if (t == 0) screen_hgt = term_prefs[0].lines - SCREEN_PAD_Y;
+		if (!term_prefs[t].lines) term_prefs[t].lines = DEFAULT_TERM_HGT;
 	}
 
 	if ((val = strstr(sec_name, "_Font"))) {
@@ -417,6 +412,11 @@ static bool read_mangrc(cptr filename) {
 			/*** Everything else is ignored ***/
 		}
 		fclose(config);
+
+		validate_main_window_dimensions();
+		/* Calculate game screen dimensions from main window dimensions. */
+		screen_wid = term_prefs[0].columns - SCREEN_PAD_X;
+		screen_hgt = term_prefs[0].lines - SCREEN_PAD_Y;
 
 		if (lighterdarkblue && client_color_map[6] == 0x0000ff)
 #ifdef USE_X11

--- a/src/client/externs.h
+++ b/src/client/externs.h
@@ -949,6 +949,7 @@ extern struct u32b_char_dict_t *u32b_char_dict_set(struct u32b_char_dict_t *star
 extern char *u32b_char_dict_get(struct u32b_char_dict_t *start, uint32_t key);
 extern struct u32b_char_dict_t *u32b_char_dict_unset(struct u32b_char_dict_t *start, uint32_t key);
 extern struct u32b_char_dict_t *u32b_char_dict_free(struct u32b_char_dict_t *start);
+extern void validate_screen_dimensions(s16b *width, s16b *height);
 
 /* common/files.c */
 extern int local_file_init(int ind, unsigned short fnum, char *fname);

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -2201,7 +2201,6 @@ static XImage *ResizeImage(Display *disp, XImage *Im,
 
 	width2 = ox * width1 / ix;
 	height2 = oy * height1 / iy;
-	printf("Resize image with masks from %dx%d to %dx%d (tile %dx%d -> %dx%d)\n",width1, height1, width2, height2, ix, iy, ox, oy);
 
 	Data = (char *)malloc(width2 * height2 * Im->bits_per_pixel / 8);
 
@@ -2454,7 +2453,6 @@ static errr term_data_init(int index, term_data *td, bool fixed, cptr name, cptr
 				td->fnt->wid, td->fnt->hgt, td->tiles->depth);
 
 		if (td->tiles != NULL && td->tilePreparation != None) {
-			printf("Using graphics for terminal %d\n", index);
 			/* Graphics hook */
 			t->pict_hook = Term_pict_x11;
 

--- a/src/client/z-term.c
+++ b/src/client/z-term.c
@@ -3352,4 +3352,11 @@ errr term_init(term *t, int w, int h, int k) {
 	return (0);
 }
 
-
+/* Validates the main window dimensions and changes them if they were not valid. */
+void validate_main_window_dimensions(void) {
+	s16b wid = term_prefs[0].columns - SCREEN_PAD_X;
+	s16b hgt = term_prefs[0].lines - SCREEN_PAD_Y;
+	validate_screen_dimensions(&wid, &hgt);
+	term_prefs[0].columns = wid + SCREEN_PAD_X;
+	term_prefs[0].lines = hgt + SCREEN_PAD_Y;
+}

--- a/src/client/z-term.h
+++ b/src/client/z-term.h
@@ -237,7 +237,8 @@ struct term
 #define TERM_XTRA_LEVEL 12	/* Change the "soft" level (optional) */
 #define TERM_XTRA_DELAY 13	/* Delay some milliseconds (optional) */
 
-
+#define DEFAULT_TERM_WID 80
+#define DEFAULT_TERM_HGT 24
 /**** Available Variables ****/
 
 extern term *Term;
@@ -292,4 +293,5 @@ extern errr term_init(term *t, int w, int h, int k);
 extern byte flick_colour(byte attr);
 extern void flicker(void);
 
+extern void validate_main_window_dimensions(void);
 #endif

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -825,3 +825,22 @@ struct u32b_char_dict_t *u32b_char_dict_free(struct u32b_char_dict_t *start) {
 	}
 	return NULL;
 }
+
+/* Validates provided screen dimensions. If the input dimensions are invalid, they will be changed to valid dimensions. */
+void validate_screen_dimensions(s16b *width, s16b *height) {
+	s16b wid = *width, hgt = *height;
+#ifdef BIG_MAP
+	if (wid > MAX_SCREEN_WID) wid = MAX_SCREEN_WID;
+	if (wid < MIN_SCREEN_WID) wid = MIN_SCREEN_WID;
+	if (hgt > MAX_SCREEN_HGT) hgt = MAX_SCREEN_HGT;
+	if (hgt < MIN_SCREEN_HGT) hgt = MIN_SCREEN_HGT;
+	/* for now until resolved: avoid dimensions whose half values aren't divisors of MAX_WID/HGT */
+	if (MAX_WID % (wid / 2)) wid = SCREEN_WID;
+	if (MAX_HGT % (hgt / 2)) hgt = SCREEN_HGT;
+#else
+	wid = SCREEN_WID;
+	hgt = SCREEN_HGT;
+#endif
+	(*width) = wid;
+	(*height) = hgt;
+}

--- a/src/server/externs.h
+++ b/src/server/externs.h
@@ -42,6 +42,7 @@ extern struct u32b_char_dict_t *u32b_char_dict_set(struct u32b_char_dict_t *star
 extern char *u32b_char_dict_get(struct u32b_char_dict_t *start, uint32_t key);
 extern struct u32b_char_dict_t *u32b_char_dict_unset(struct u32b_char_dict_t *start, uint32_t key);
 extern struct u32b_char_dict_t *u32b_char_dict_free(struct u32b_char_dict_t *start);
+extern bool validate_screen_dimensions(s16b *width, s16b *height);
 
 /* common/files.c */
 extern int local_file_init(int ind, unsigned short fnum, char *fname);

--- a/src/server/nserver.c
+++ b/src/server/nserver.c
@@ -5114,18 +5114,7 @@ static int Receive_play(int ind) {
 			connp->Client_setup.screen_hgt = screen_hgt_32b;
 
 			/* fix limits */
-#ifdef BIG_MAP
-			if (connp->Client_setup.screen_wid > MAX_SCREEN_WID) connp->Client_setup.screen_wid = MAX_SCREEN_WID;
-			if (connp->Client_setup.screen_wid < MIN_SCREEN_WID) connp->Client_setup.screen_wid = MIN_SCREEN_WID;
-			if (connp->Client_setup.screen_hgt > MAX_SCREEN_HGT) connp->Client_setup.screen_hgt = MAX_SCREEN_HGT;
-			if (connp->Client_setup.screen_hgt < MIN_SCREEN_HGT) connp->Client_setup.screen_hgt = MIN_SCREEN_HGT;
-			/* for now until resolved: avoid dimensions whose half values aren't divisors of MAX_WID/HGT */
-			if (MAX_WID % (connp->Client_setup.screen_wid / 2)) connp->Client_setup.screen_wid = SCREEN_WID;
-			if (MAX_HGT % (connp->Client_setup.screen_hgt / 2)) connp->Client_setup.screen_hgt = SCREEN_HGT;
-#else
-			connp->Client_setup.screen_wid = SCREEN_WID;
-			connp->Client_setup.screen_hgt = SCREEN_HGT;
-#endif
+			validate_screen_dimensions(&connp->Client_setup.screen_wid, &connp->Client_setup.screen_hgt);
 		} else {
 			connp->Client_setup.screen_wid = SCREEN_WID;
 			connp->Client_setup.screen_hgt = SCREEN_HGT;
@@ -12648,18 +12637,7 @@ static int Receive_screen_dimensions(int ind) {
 
 
 		/* fix limits */
-#ifdef BIG_MAP
-		if (p_ptr->screen_wid > MAX_SCREEN_WID) p_ptr->screen_wid = MAX_SCREEN_WID;
-		if (p_ptr->screen_wid < MIN_SCREEN_WID) p_ptr->screen_wid = MIN_SCREEN_WID;
-		if (p_ptr->screen_hgt > MAX_SCREEN_HGT) p_ptr->screen_hgt = MAX_SCREEN_HGT;
-		if (p_ptr->screen_hgt < MIN_SCREEN_HGT) p_ptr->screen_hgt = MIN_SCREEN_HGT;
-		/* for now until resolved: avoid dimensions whose half values aren't divisors of MAX_WID/HGT */
-		if (MAX_WID % (p_ptr->screen_wid / 2)) p_ptr->screen_wid = SCREEN_WID;
-		if (MAX_HGT % (p_ptr->screen_hgt / 2)) p_ptr->screen_hgt = SCREEN_HGT;
-#else
-		p_ptr->screen_wid = SCREEN_WID;
-		p_ptr->screen_hgt = SCREEN_HGT;
-#endif
+		validate_screen_dimensions(&p_ptr->screen_wid, &p_ptr->screen_hgt);
 
 		connp->Client_setup.screen_wid = p_ptr->screen_wid;
 		connp->Client_setup.screen_hgt = p_ptr->screen_hgt;


### PR DESCRIPTION
I've sometimes experienced weird error after x11 client started a game in big map mode. Picture more than words, animated gif more than a picture:
![tomenet v4 8 1 0 x11-big-map-bug](https://user-images.githubusercontent.com/5408235/183811655-c36dbf99-7ee7-4842-81a2-0c3a49053934.gif)

So I investigated and found out the reason. A game before, when I selected big map mode in menu, the window resized to big mode, but my screen resolution was to small to fully resize (when I undecorate window or move the title bar up past the screen, the window will enlarge itself). So the window was not fully resized after big map enable. Then, when the client was exited, the window info got to be written into tomenetrc. And the main window lines value gets calculated from current window height, which was smaller than it ought to be. That's why the written lines count was 45 instead of 46 for fully sized window.

Then on next start, the smaller window size gets loaded from tomenetrc and screen dimensions were calculated and sent to server. The server validated the dimensions and found the screen height of 43 lines invalid, corrected them to 22 and goes on as if no big screen was selected. The client then draws only 22 lines, although he is sized for 43.

This was fixed by deriving the lines for main window from screen_hgt variable instead of current window size.
And for the case when somebody manually edits the line height of main window, I also decided to validate the loaded screen width and height values with the same function as server does.
