### PR TITLE
X11 resize rewrites

### DIFF
--- a/src/client/c-init.c
+++ b/src/client/c-init.c
@@ -3422,10 +3422,6 @@ static void quit_hook(cptr s) {
 	if (rl_connection_state >= 2) return;
 #endif
 
-#ifndef WINDOWS
-	write_mangrc(FALSE, FALSE, FALSE);
-#endif
-
 #ifdef UNIX_SOCKETS
 	SocketCloseAll();
 #endif
@@ -3446,6 +3442,10 @@ static void quit_hook(cptr s) {
 
 	/* plog_hook must not be called anymore because the terminal is gone */
 	plog_aux = NULL;
+
+#ifndef WINDOWS
+	write_mangrc(FALSE, FALSE, FALSE);
+#endif
 }
 
 

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -431,45 +431,30 @@ static bool read_mangrc(cptr filename) {
 #ifdef USE_X11
 /* linux clients: save subwindow prefs to .tomenetrc - C. Blue */
 static void write_mangrc_aux(int t, cptr sec_name, FILE *cfg_file) {
-	int x, y, c, r;
-	char font_name[1024];
-
-	x11win_getinfo(t, &x, &y, &c, &r, font_name);
 
 	if (t != 0) {
 		fputs(format("%s_Title\t%s\n", sec_name, ang_term_name[t]), cfg_file);
 		fputs(format("%s_Visible\t%c\n", sec_name, term_prefs[t].visible ? '1' : '0'), cfg_file);
 	}
-	if (x != -32000) /* don't save windows in minimized state */
-		fputs(format("%s_X\t\t%d\n", sec_name, x), cfg_file);
-//		fputs(format("%s_X\t\t%d\n", sec_name, term_prefs[t].x), cfg_file);
-	if (y != -32000) /* don't save windows in minimized state */
-		fputs(format("%s_Y\t\t%d\n", sec_name, y), cfg_file);
-//		fputs(format("%s_Y\t\t%d\n", sec_name, term_prefs[t].y), cfg_file);
+	if (term_prefs[t].x != -32000) /* don't save windows in minimized state */
+		fputs(format("%s_X\t\t%d\n", sec_name, term_prefs[t].x), cfg_file);
+	if (term_prefs[t].y != -32000) /* don't save windows in minimized state */
+		fputs(format("%s_Y\t\t%d\n", sec_name, term_prefs[t].y), cfg_file);
 	if (t != 0) {
-#if 0
 		fputs(format("%s_Columns\t%d\n", sec_name, term_prefs[t].columns), cfg_file);
 		fputs(format("%s_Lines\t%d\n", sec_name, term_prefs[t].lines), cfg_file);
-#else /* if user has mouse-resized a window, save the new dimensions */
-		fputs(format("%s_Columns\t%d\n", sec_name, c), cfg_file);
-		fputs(format("%s_Lines\t%d\n", sec_name, r), cfg_file);
-#endif
-		fputs(format("%s_Font\t%s\n", sec_name, font_name), cfg_file);
+		fputs(format("%s_Font\t%s\n", sec_name, term_prefs[t].font), cfg_file);
 	} else {
 		/* one more tab, or formatting looks bad ;) */
-		fputs(format("%s_Font\t\t%s\n", sec_name, font_name), cfg_file);
-		/* If user has mouse-resized the main window, the dimensions get corrected back to valid dimensions, which are then reflected in screen_hgt variable. */
-		fputs(format("%s_Lines\t%d\n", sec_name, screen_hgt + SCREEN_PAD_Y), cfg_file);
+		fputs(format("%s_Font\t\t%s\n", sec_name, term_prefs[t].font), cfg_file);
+		fputs(format("%s_Lines\t%d\n", sec_name, term_prefs[t].lines), cfg_file);
 	}
 	fputs("\n", cfg_file);
 }
 
 /* linux clients: save one line of subwindow prefs to .tomenetrc - C. Blue */
 static void write_mangrc_aux_line(int t, cptr sec_name, char *buf_org) {
-	char buf[1024], *ter_name = buf_org + strlen(sec_name), font_name[1024] = { '\0' };
-	int x = -32000, y = -32000, c = 0, r = 24;
-
-	x11win_getinfo(t, &x, &y, &c, &r, font_name);
+	char buf[1024], *ter_name = buf_org + strlen(sec_name);
 #if 0 /* we still want to save at least the new visibility state, if it was toggled via in-game menu */
 	if (!c) return; /* invisible window? */
 #endif
@@ -483,28 +468,23 @@ static void write_mangrc_aux_line(int t, cptr sec_name, char *buf_org) {
 	} else if (!strncmp(ter_name, "_Visible", 8)) {
 		if (t != 0)
 			sprintf(buf, "%s_Visible\t%c\n", sec_name, term_prefs[t].visible ? '1' : '0');
-	} else if (c && !strncmp(ter_name, "_X", 2)) {
-		if (x != -32000) /* don't save windows in minimized state */
-			sprintf(buf, "%s_X\t\t%d\n", sec_name, x);
-//			sprintf(buf, "%s_X\t\t%d\n", sec_name, term_prefs[t].x);
-	} else if (c && !strncmp(ter_name, "_Y", 2)) {
-		if (y != -32000) /* don't save windows in minimized state */
-			sprintf(buf, "%s_Y\t\t%d\n", sec_name, y);
-//			sprintf(buf, "%s_Y\t\t%d\n", sec_name, term_prefs[t].y);
-	} else if (c && !strncmp(ter_name, "_Columns", 8)) {
+	} else if (term_prefs[t].visible && !strncmp(ter_name, "_X", 2)) {
+		if (term_prefs[t].x != -32000) /* don't save windows in minimized state */
+			sprintf(buf, "%s_X\t\t%d\n", sec_name, term_prefs[t].x);
+	} else if (term_prefs[t].visible && !strncmp(ter_name, "_Y", 2)) {
+		if (term_prefs[t].y != -32000) /* don't save windows in minimized state */
+			sprintf(buf, "%s_Y\t\t%d\n", sec_name, term_prefs[t].y);
+	} else if (term_prefs[t].visible && !strncmp(ter_name, "_Columns", 8)) {
 		if (t != 0)
-			sprintf(buf, "%s_Columns\t%d\n", sec_name, c);
-	} else if (c && !strncmp(ter_name, "_Lines", 6)) {
+			sprintf(buf, "%s_Columns\t%d\n", sec_name, term_prefs[t].columns);
+	} else if (term_prefs[t].visible && !strncmp(ter_name, "_Lines", 6)) {
+			sprintf(buf, "%s_Lines\t%d\n", sec_name, term_prefs[t].lines);
+	} else if (!strncmp(ter_name, "_Font", 5) && term_prefs[t].font[0] != '\0') {
 		if (t != 0)
-			sprintf(buf, "%s_Lines\t%d\n", sec_name, r);
-		else
-			sprintf(buf, "%s_Lines\t%d\n", sec_name, screen_hgt + SCREEN_PAD_Y);
-	} else if (!strncmp(ter_name, "_Font", 5) && font_name[0] != '\0') {
-		if (t != 0)
-			sprintf(buf, "%s_Font\t%s\n", sec_name, font_name);
+			snprintf(buf, 1024, "%s_Font\t%s\n", sec_name, term_prefs[t].font);
 		else
 			/* one more tab, or formatting looks bad ;) */
-			sprintf(buf, "%s_Font\t\t%s\n", sec_name, font_name);
+			snprintf(buf, 1024, "%s_Font\t\t%s\n", sec_name, term_prefs[t].font);
 	}
 
 	strcpy(buf_org, buf);

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -413,7 +413,7 @@ static bool read_mangrc(cptr filename) {
 		}
 		fclose(config);
 
-		validate_main_window_dimensions();
+		validate_term_screen_dimensions(&(term_prefs[0].columns), &(term_prefs[0].lines));
 		/* Calculate game screen dimensions from main window dimensions. */
 		screen_wid = term_prefs[0].columns - SCREEN_PAD_X;
 		screen_hgt = term_prefs[0].lines - SCREEN_PAD_Y;

--- a/src/client/externs.h
+++ b/src/client/externs.h
@@ -26,7 +26,6 @@ extern errr init_x11(void);
     extern bool term_get_visibility(int term_idx);
  #endif
 
-extern void x11win_getinfo(int term_idx, int *x, int *y, int *c, int *r, char *fnt_name);
 extern void resize_main_window_x11(int cols, int rows);
 extern bool ask_for_bigmap(void);
 extern void get_screen_font_name(char *buf);

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -31,28 +31,6 @@
 #include <time.h>
 
 /*
- * OPTION: Allow the use of a "Mirror Window", if supported
- */
-#define GRAPHIC_MIRROR
-
-/*
- * OPTION: Allow the use of a "Recall Window", if supported
- */
-#define GRAPHIC_RECALL
-
-/*
- * OPTION: Allow the use of a "Choice Window", if supported
- */
-#define GRAPHIC_CHOICE
-
-/* More options: Enable windows 5..8 (term-4..term-7) - C. Blue */
-#define GRAPHIC_TERM_4
-#define GRAPHIC_TERM_5
-#define GRAPHIC_TERM_6
-#define GRAPHIC_TERM_7
-
-
-/*
  * Notes on Colors:
  *
  *   1) On a monochrome (or "fake-monochrome") display, all colors
@@ -1220,45 +1198,28 @@ static void timespec_add_ns(struct timespec *t, unsigned int ns) {
 	}
 }
 
-#ifdef GRAPHIC_MIRROR
-
 /*
  * The (optional) "mirror" window
  */
 static term_data mirror;
-
-#endif
-
-#ifdef GRAPHIC_RECALL
 
 /*
  * The (optional) "recall" window
  */
 static term_data recall;
 
-#endif
-
-#ifdef GRAPHIC_CHOICE
-
 /*
  * The (optional) "choice" window
  */
 static term_data choice;
 
-#endif
-
-#ifdef GRAPHIC_TERM_4
+/*
+ * Other (optional) windows.
+ */
 static term_data term_4;
-#endif
-#ifdef GRAPHIC_TERM_5
 static term_data term_5;
-#endif
-#ifdef GRAPHIC_TERM_6
 static term_data term_6;
-#endif
-#ifdef GRAPHIC_TERM_7
 static term_data term_7;
-#endif
 
 
 /*
@@ -1505,7 +1466,6 @@ static errr CheckEvent(bool wait) {
 		t_idx = 0;
 	}
 
-//#ifdef GRAPHIC_MIRROR
 	/* Mirror window, inner window */
 	else if (term_mirror && xev->xany.window == mirror.inner->win) {
 		td = &mirror;
@@ -1519,97 +1479,84 @@ static errr CheckEvent(bool wait) {
 		iwin = td->outer;
 		t_idx = 1;
 	}
-//#endif
 
-//#ifdef GRAPHIC_RECALL
 	/* Recall window, inner window */
 	else if (term_recall && xev->xany.window == recall.inner->win) {
 		td = &recall;
 		iwin = td->inner;
 		t_idx = 2;
 	}
-	/* Recall Window, outer window */
+	/* Recall window, outer window */
 	else if (term_recall && xev->xany.window == recall.outer->win) {
 		td = &recall;
 		iwin = td->outer;
 		t_idx = 2;
 	}
-//#endif
 
-//#ifdef GRAPHIC_CHOICE
 	/* Choice window, inner window */
 	else if (term_choice && xev->xany.window == choice.inner->win) {
 		td = &choice;
 		iwin = td->inner;
 		t_idx = 3;
 	}
-	/* Choice Window, outer window */
+	/* Choice window, outer window */
 	else if (term_choice && xev->xany.window == choice.outer->win) {
 		td = &choice;
 		iwin = td->outer;
 		t_idx = 3;
 	}
-//#endif
 
-//#ifdef GRAPHIC_TERM_4
-	/* Choice window, inner window */
+	/* Other window, inner window */
 	else if (term_term_4 && xev->xany.window == term_4.inner->win) {
 		td = &term_4;
 		iwin = td->inner;
 		t_idx = 4;
 	}
-	/* Choice Window, outer window */
+	/* Other window, outer window */
 	else if (term_term_4 && xev->xany.window == term_4.outer->win) {
 		td = &term_4;
 		iwin = td->outer;
 		t_idx = 4;
 	}
-//#endif
 
-//#ifdef GRAPHIC_TERM_5
-	/* Choice window, inner window */
+	/* Other window, inner window */
 	else if (term_term_5 && xev->xany.window == term_5.inner->win) {
 		td = &term_5;
 		iwin = td->inner;
 		t_idx = 5;
 	}
-	/* Choice Window, outer window */
+	/* Other window, outer window */
 	else if (term_term_5 && xev->xany.window == term_5.outer->win) {
 		td = &term_5;
 		iwin = td->outer;
 		t_idx = 5;
 	}
-//#endif
 
-//#ifdef GRAPHIC_TERM_6
-	/* Choice window, inner window */
+	/* Other window, inner window */
 	else if (term_term_6 && xev->xany.window == term_6.inner->win) {
 		td = &term_6;
 		iwin = td->inner;
 		t_idx = 6;
 	}
-	/* Choice Window, outer window */
+	/* Other window, outer window */
 	else if (term_term_6 && xev->xany.window == term_6.outer->win) {
 		td = &term_6;
 		iwin = td->outer;
 		t_idx = 6;
 	}
-//#endif
 
-//#ifdef GRAPHIC_TERM_7
-	/* Choice window, inner window */
+	/* Other window, inner window */
 	else if (term_term_7 && xev->xany.window == term_7.inner->win) {
 		td = &term_7;
 		iwin = td->inner;
 		t_idx = 7;
 	}
-	/* Choice Window, outer window */
+	/* Other window, outer window */
 	else if (term_term_7 && xev->xany.window == term_7.outer->win) {
 		td = &term_7;
 		iwin = td->outer;
 		t_idx = 7;
 	}
-//#endif
 
 
 	/* Unknown window */
@@ -1621,7 +1568,6 @@ static errr CheckEvent(bool wait) {
 
 	/* Hack -- activate the window */
 	Infowin_set(iwin);
-
 
 	/* Switch on the Type */
 	switch (xev->type) {
@@ -2761,155 +2707,141 @@ errr init_x11(void) {
 	}
 #endif /* USE_GRAPHICS */
 
-{ /* Main window is always visible */
-	/* Check environment for "screen" font */
-	fnt_name = getenv("TOMENET_X11_FONT_SCREEN");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[0].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_SCREEN;
-	/* Initialize the screen */
-//	term_data_init(0, &screen, TRUE, "TomeNET", fnt_name);
-//	term_data_init(0, &screen, TRUE, ang_term_name[0], fnt_name);
-	/* allow resizing, for font changes */
-	term_data_init(0, &screen, FALSE, ang_term_name[0], fnt_name);
-	term_screen = Term;
-	ang_term[0] = Term;
-}
+	{ /* Main window is always visible */
+		/* Check environment for "screen" font */
+		fnt_name = getenv("TOMENET_X11_FONT_SCREEN");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[0].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_SCREEN;
+		/* Initialize the screen */
+		//	term_data_init(0, &screen, TRUE, "TomeNET", fnt_name);
+		//	term_data_init(0, &screen, TRUE, ang_term_name[0], fnt_name);
+		/* allow resizing, for font changes */
+		term_data_init(0, &screen, FALSE, ang_term_name[0], fnt_name);
+		term_screen = Term;
+		ang_term[0] = Term;
+	}
 
-#ifdef GRAPHIC_MIRROR
-if (term_prefs[1].visible) {
-	/* Check environment for "mirror" font */
-	fnt_name = getenv("TOMENET_X11_FONT_MIRROR");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[1].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_MIRROR;
+	if (term_prefs[1].visible) {
+		/* Check environment for "mirror" font */
+		fnt_name = getenv("TOMENET_X11_FONT_MIRROR");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[1].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_MIRROR;
 
-	/* Initialize the mirror window */
-	term_data_init(1, &mirror, FALSE, ang_term_name[1], fnt_name);
-	term_mirror = Term;
-	ang_term[1] = Term;
+		/* Initialize the mirror window */
+		term_data_init(1, &mirror, FALSE, ang_term_name[1], fnt_name);
+		term_mirror = Term;
+		ang_term[1] = Term;
 
-}
-#endif
+	}
 
-#ifdef GRAPHIC_RECALL
-if (term_prefs[2].visible) {
-	/* Check environment for "recall" font */
-	fnt_name = getenv("TOMENET_X11_FONT_RECALL");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[2].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_RECALL;
+	if (term_prefs[2].visible) {
+		/* Check environment for "recall" font */
+		fnt_name = getenv("TOMENET_X11_FONT_RECALL");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[2].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_RECALL;
 
-	/* Initialize the recall window */
-	term_data_init(2, &recall, FALSE, ang_term_name[2], fnt_name);
-	term_recall = Term;
-	ang_term[2] = Term;
+		/* Initialize the recall window */
+		term_data_init(2, &recall, FALSE, ang_term_name[2], fnt_name);
+		term_recall = Term;
+		ang_term[2] = Term;
 
-}
-#endif
+	}
 
-#ifdef GRAPHIC_CHOICE
-if (term_prefs[3].visible) {
-	/* Check environment for "choice" font */
-	fnt_name = getenv("TOMENET_X11_FONT_CHOICE");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[3].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_CHOICE;
+	if (term_prefs[3].visible) {
+		/* Check environment for "choice" font */
+		fnt_name = getenv("TOMENET_X11_FONT_CHOICE");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[3].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_CHOICE;
 
-	/* Initialize the choice window */
-	term_data_init(3, &choice, FALSE, ang_term_name[3], fnt_name);
-	term_choice = Term;
-	ang_term[3] = Term;
-}
-#endif
+		/* Initialize the choice window */
+		term_data_init(3, &choice, FALSE, ang_term_name[3], fnt_name);
+		term_choice = Term;
+		ang_term[3] = Term;
+	}
 
-#ifdef GRAPHIC_TERM_4
-if (term_prefs[4].visible) {
-	/* Check environment for "term4" font */
-	fnt_name = getenv("TOMENET_X11_FONT_TERM_4");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[4].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_4;
+	if (term_prefs[4].visible) {
+		/* Check environment for "term4" font */
+		fnt_name = getenv("TOMENET_X11_FONT_TERM_4");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[4].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_4;
 
-	/* Initialize the term_4 window */
-	term_data_init(4, &term_4, FALSE, ang_term_name[4], fnt_name);
-	term_term_4 = Term;
-	ang_term[4] = Term;
+		/* Initialize the term_4 window */
+		term_data_init(4, &term_4, FALSE, ang_term_name[4], fnt_name);
+		term_term_4 = Term;
+		ang_term[4] = Term;
 
-}
-#endif
+	}
 
-#ifdef GRAPHIC_TERM_5
-if (term_prefs[5].visible) {
-	/* Check environment for "term5" font */
-	fnt_name = getenv("TOMENET_X11_FONT_TERM_5");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[5].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_5;
+	if (term_prefs[5].visible) {
+		/* Check environment for "term5" font */
+		fnt_name = getenv("TOMENET_X11_FONT_TERM_5");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[5].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_5;
 
-	/* Initialize the term_5 window */
-	term_data_init(5, &term_5, FALSE, ang_term_name[5], fnt_name);
-	term_term_5 = Term;
-	ang_term[5] = Term;
+		/* Initialize the term_5 window */
+		term_data_init(5, &term_5, FALSE, ang_term_name[5], fnt_name);
+		term_term_5 = Term;
+		ang_term[5] = Term;
 
-}
-#endif
+	}
 
-#ifdef GRAPHIC_TERM_6
-if (term_prefs[6].visible) {
-	/* Check environment for "term6" font */
-	fnt_name = getenv("TOMENET_X11_FONT_TERM_6");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[6].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_6;
+	if (term_prefs[6].visible) {
+		/* Check environment for "term6" font */
+		fnt_name = getenv("TOMENET_X11_FONT_TERM_6");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[6].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_6;
 
-	/* Initialize the term_6 window */
-	term_data_init(6, &term_6, FALSE, ang_term_name[6], fnt_name);
-	term_term_6 = Term;
-	ang_term[6] = Term;
+		/* Initialize the term_6 window */
+		term_data_init(6, &term_6, FALSE, ang_term_name[6], fnt_name);
+		term_term_6 = Term;
+		ang_term[6] = Term;
 
-}
-#endif
+	}
 
-#ifdef GRAPHIC_TERM_7
-if (term_prefs[7].visible) {
-	/* Check environment for "term7" font */
-	fnt_name = getenv("TOMENET_X11_FONT_TERM_7");
-	/* Check environment for "base" font */
-	if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
-	/* Use loaded (from config file) or predefined default font */
-	if (!fnt_name) fnt_name = term_prefs[7].font;
-	/* paranoia; use the default */
-	if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_7;
+	if (term_prefs[7].visible) {
+		/* Check environment for "term7" font */
+		fnt_name = getenv("TOMENET_X11_FONT_TERM_7");
+		/* Check environment for "base" font */
+		if (!fnt_name) fnt_name = getenv("TOMENET_X11_FONT");
+		/* Use loaded (from config file) or predefined default font */
+		if (!fnt_name) fnt_name = term_prefs[7].font;
+		/* paranoia; use the default */
+		if (!fnt_name) fnt_name = DEFAULT_X11_FONT_TERM_7;
 
-	/* Initialize the term_7 window */
-	term_data_init(7, &term_7, FALSE, ang_term_name[7], fnt_name);
-	term_term_7 = Term;
-	ang_term[7] = Term;
+		/* Initialize the term_7 window */
+		term_data_init(7, &term_7, FALSE, ang_term_name[7], fnt_name);
+		term_term_7 = Term;
+		ang_term[7] = Term;
 
-}
-#endif
+	}
 
 
 	/* Activate the "Angband" window screen */

--- a/src/client/z-term.c
+++ b/src/client/z-term.c
@@ -3354,11 +3354,30 @@ errr term_init(term *t, int w, int h, int k) {
 	return (0);
 }
 
-/* Validates the main window dimensions and changes them if they were not valid. */
-void validate_main_window_dimensions(void) {
-	s16b wid = term_prefs[0].columns - SCREEN_PAD_X;
-	s16b hgt = term_prefs[0].lines - SCREEN_PAD_Y;
+/* Validates the screen terminal dimensions and changes them if they are not valid.
+ * In this case the 'cols' and 'rows' is set to nearest lower valid value and if there is no such one, than to nearest higher valid value. */
+void validate_term_screen_dimensions(int *cols, int *rows) {
+	s16b wid = (s16b)(*cols) - SCREEN_PAD_X;
+	s16b hgt = (s16b)(*rows) - SCREEN_PAD_Y;
 	validate_screen_dimensions(&wid, &hgt);
-	term_prefs[0].columns = wid + SCREEN_PAD_X;
-	term_prefs[0].lines = hgt + SCREEN_PAD_Y;
+	(*cols) = wid + SCREEN_PAD_X;
+	(*rows) = hgt + SCREEN_PAD_Y;
+}
+
+/* Validates the dimensions for terminal under index 'term_idx'.
+ * If the index is invalid, cols and rows will be set to 0.
+ * If the dimensions for terminal are invalid, they will be changed to valid values.
+ * In this case the 'cols' and 'rows' is set to nearest lower valid value and if there is no such one, than to nearest higher valid value. */
+void validate_term_dimensions(int term_idx, int *cols, int *rows) {
+	if (term_idx < 0 || term_idx >= ANGBAND_TERM_MAX) {
+		(*cols) = 0;
+		(*rows) = 0;
+		return;
+	}
+	if (term_idx == 0) {
+		validate_term_screen_dimensions(cols, rows);
+	} else {
+		if ((*cols) < 1) (*cols) = 1;
+		if ((*rows) < 1) (*rows) = 1;
+	}
 }

--- a/src/client/z-term.h
+++ b/src/client/z-term.h
@@ -28,7 +28,7 @@ typedef struct term_win term_win;
 struct term_win
 {
 	bool cu, cv;
-	byte cx, cy;
+	int cx, cy;
 
 	byte **a;
 	char32_t **c;
@@ -171,14 +171,14 @@ struct term
 	key_queue *keys_old;
 	s32b key_size_orig;
 
-	byte wid;
-	byte hgt;
+	int wid;
+	int hgt;
 
-	byte y1;
-	byte y2;
+	int y1;
+	int y2;
 
-	byte *x1;
-	byte *x2;
+	int *x1;
+	int *x2;
 
 	term_win *old;
 	term_win *scr;
@@ -239,6 +239,7 @@ struct term
 
 #define DEFAULT_TERM_WID 80
 #define DEFAULT_TERM_HGT 24
+
 /**** Available Variables ****/
 
 extern term *Term;

--- a/src/client/z-term.h
+++ b/src/client/z-term.h
@@ -293,5 +293,6 @@ extern errr term_init(term *t, int w, int h, int k);
 extern byte flick_colour(byte attr);
 extern void flicker(void);
 
-extern void validate_main_window_dimensions(void);
+extern void validate_term_screen_dimensions(int *cols, int *rows);
+extern void validate_term_dimensions(int term_idx, int *cols, int *rows);
 #endif

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -826,7 +826,8 @@ struct u32b_char_dict_t *u32b_char_dict_free(struct u32b_char_dict_t *start) {
 	return NULL;
 }
 
-/* Validates provided screen dimensions. If the input dimensions are invalid, they will be changed to valid dimensions. */
+/* Validates provided screen dimensions. If the input dimensions are invalid, they will be changed to valid dimensions.
+ * In this case the 'width' and 'height' is set to nearest lower valid value and if there is no such one, than to nearest higher valid value. */
 void validate_screen_dimensions(s16b *width, s16b *height) {
 	s16b wid = *width, hgt = *height;
 #ifdef BIG_MAP


### PR DESCRIPTION
Hello, I've played with the x11 client and made some resize code rewrites. Now there is a slight delay after user resizes the terminal window, and when the window makes dimension validation and additional window size corrections. This means less flickering and weird resizes, when mouse-resizing the main window.

I have also found and fixed a bug, when a text window (e.g. chat) becomes blank, when resizing to more than 255 cols (and maybe rows too).

You'll find more details in commits.