### PR TITLE
Gcu graphics fix

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -742,11 +742,11 @@ bool write_mangrc(bool creds_only, bool update_creds, bool audiopacks_only) {
 			fputs("#colormap_15\t\t#c79d55\n", config2);
 			fputs("\n", config2);
 
-//#ifdef USE_GRAPHICS
 			fputs(format("graphics\t\t%s\n", use_graphics ? "1" : "0"), config2);
+#ifdef USE_GRAPHICS
 			fputs(format("graphic_tiles\t\t%s\n", graphic_tiles), config2);
+#endif
 			fputs("\n", config2);
-//#endif
 //#ifdef USE_SOUND
 			fputs(format("sound\t\t\t%s\n", use_sound_org ? "1" : "0"), config2);
 //#endif

--- a/src/client/externs.h
+++ b/src/client/externs.h
@@ -319,7 +319,9 @@ extern cptr ANGBAND_DIR_GAME;
 
 extern bool disable_numlock;
 extern bool use_graphics;
+#ifdef USE_GRAPHICS
 extern char graphic_tiles[256];
+#endif
 extern bool use_sound, use_sound_org;
 extern bool quiet_mode;
 extern bool noweather_mode;

--- a/src/client/main-gcu.c
+++ b/src/client/main-gcu.c
@@ -874,6 +874,8 @@ errr init_gcu(void) {
 	    !getenv("XTERM_VERSION")))
 		setenv("TERM", "xterm-16color", -1);
 
+	/* Graphic tiles are not supported in GCU client */
+	use_graphics = FALSE;
 
 	/* BIG_MAP is currently not supported in GCU client */
 	c_cfg.big_map = FALSE;

--- a/src/client/variable.c
+++ b/src/client/variable.c
@@ -205,9 +205,10 @@ cptr ANGBAND_DIR_XTRA;
 cptr ANGBAND_DIR_GAME;
 
 bool disable_numlock;
-/* TODO hide use_graphics inside USE_GRAPHICS ifdef everywhere jEzEk */
 bool use_graphics;
+#ifdef USE_GRAPHICS
 char graphic_tiles[256] = "\0";
+#endif
 #ifdef USE_SOUND_2010
 bool use_sound = TRUE, use_sound_org = TRUE; //ought to be set via TOMENET_SOUND environment var in linux, probably (compare TOMENET_GRAPHICS) -C. Blue
 #else


### PR DESCRIPTION
When running the GCU client (x11 client with -c option) and the `use_graphics` is enabled in tomenet rc, the game visuals were broken.

The fix was really easy. It was needed to turn off `use_graphics` in `client/main_gcu.c`.

I've also hid all `graphic_tiles` variables inside `USE_GRAPHICS` macro.