### PR TITLE
X11 font options updates

### DIFF
--- a/src/client/c-birth.c
+++ b/src/client/c-birth.c
@@ -124,7 +124,13 @@ static void choose_name(void) {
 #endif
 		if (askfor_aux(tmp, ACCNAME_LEN - 1, 0)) strcpy(nick, tmp);
 		/* at this point: ESC = quit game */
-		else exit(0);
+		else {
+			/* Nuke each term before exit. */
+			for (int j = ANGBAND_TERM_MAX - 1; j >= 0; j--) {
+				if (ang_term[j]) term_nuke(ang_term[j]);
+			}
+			exit(0);
+		}
 
 		/* All done */
 		break;

--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -8767,7 +8767,7 @@ static void do_cmd_options_fonts(void) {
 	/* Interact */
 	while (go) {
 		/* Prompt XXX XXX XXX */
-		Term_putstr(0, 0, -1, TERM_WHITE, "  (<\377ydir\377w>, \377yv\377w (visibility), \377y-\377w/\377y+\377w (smaller/bigger), \377yENTER\377w (enter font name), \377yESC\377w)");
+		Term_putstr(0, 0, -1, TERM_WHITE, "  (<\377ydir\377w>, \377yv\377w (visibility), \377y-\377w/\377y+\377w,\377y=\377w (smaller/bigger), \377yENTER\377w (enter font name), \377yESC\377w)");
 		Term_putstr(0, 1, -1, TERM_WHITE, format("  (%d font%s and %d graphic font%s available, \377yl\377w to list in message window)", fonts, fonts == 1 ? "" : "s", graphic_fonts, graphic_fonts == 1 ? "" : "s"));
 
 		/* Display the windows */
@@ -8819,6 +8819,7 @@ static void do_cmd_options_fonts(void) {
 			term_toggle_visibility(y);
 			break;
 
+		case '=':
 		case '+':
 			/* find out which of the fonts in lib/xtra/fonts we're currently using */
 			if ((window_flag[y] & PW_MINIMAP) && graphic_fonts > 0)

--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -8817,7 +8817,6 @@ static void do_cmd_options_fonts(void) {
 		case 'v':
 			if (y == 0) break; /* main window cannot be invisible */
 			term_toggle_visibility(y);
-			Term_putstr(0, 15, -1, TERM_YELLOW, "-- Changes to window visibilities require a restart of the client --");
 			break;
 
 		case '+':

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -470,16 +470,16 @@ static void write_mangrc_aux_line(int t, cptr sec_name, char *buf_org) {
 	} else if (!strncmp(ter_name, "_Visible", 8)) {
 		if (t != 0)
 			sprintf(buf, "%s_Visible\t%c\n", sec_name, term_prefs[t].visible ? '1' : '0');
-	} else if (term_prefs[t].visible && !strncmp(ter_name, "_X", 2)) {
+	} else if (!strncmp(ter_name, "_X", 2)) {
 		if (term_prefs[t].x != -32000) /* don't save windows in minimized state */
 			sprintf(buf, "%s_X\t\t%d\n", sec_name, term_prefs[t].x);
-	} else if (term_prefs[t].visible && !strncmp(ter_name, "_Y", 2)) {
+	} else if (!strncmp(ter_name, "_Y", 2)) {
 		if (term_prefs[t].y != -32000) /* don't save windows in minimized state */
 			sprintf(buf, "%s_Y\t\t%d\n", sec_name, term_prefs[t].y);
-	} else if (term_prefs[t].visible && !strncmp(ter_name, "_Columns", 8)) {
+	} else if (!strncmp(ter_name, "_Columns", 8)) {
 		if (t != 0)
 			sprintf(buf, "%s_Columns\t%d\n", sec_name, term_prefs[t].columns);
-	} else if (term_prefs[t].visible && !strncmp(ter_name, "_Lines", 6)) {
+	} else if (!strncmp(ter_name, "_Lines", 6)) {
 			sprintf(buf, "%s_Lines\t%d\n", sec_name, term_prefs[t].lines);
 	} else if (!strncmp(ter_name, "_Font", 5) && term_prefs[t].font[0] != '\0') {
 		if (t != 0)

--- a/src/client/main-gcu.c
+++ b/src/client/main-gcu.c
@@ -901,10 +901,13 @@ errr init_gcu(void) {
 	if (initscr() == (WINDOW*)ERR) return(-1);
 #endif
 
-
-	/* Hack -- Require large screen, or Quit with message */
-	i = ((LINES < 24) || (COLS < 80));
-	if (i) quit("Angband needs an 80x24 'curses' screen");
+	/* Require large screen, or fail with a message. */
+	if ((LINES < 24) || (COLS < 80)) {
+		fprintf(stderr, "Angband needs an 80x24 'curses' screen\n");
+		/* Restore terminal first, then fail. */
+		endwin();
+		return(-2);
+	}
 
 
 	/* set OS-specific resize_main_window() hook */

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -2721,8 +2721,7 @@ static errr x11_term_init(int term_id) {
 	/* Initialize the terminal window, allow resizing, for font changes. */
 	errr err = term_data_init(term_id, x11_terms_term_data[term_id], FALSE, ang_term_name[term_id], fnt_name);
 	/* Store created terminal with X11 term data to ang_term array, even if term_data_init failed, but only if there is one. */
-	int activated_term_idx = term_data_to_term_idx(Term->data);
-	if (activated_term_idx == term_id) {
+	if (Term && term_data_to_term_idx(Term->data) == term_id) {
 		ang_term[term_id] = Term;
 	}
 

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -2386,9 +2386,16 @@ static errr term_data_init(int index, term_data *td, bool fixed, cptr name, cptr
 
 	/* Prepare the standard font */
 	MAKE(td->fnt, infofnt);
+	infofnt *old_infofnt = Infofnt;
 	Infofnt_set(td->fnt);
 	if (Infofnt_init_data(font) == -1) {
-		fprintf(stderr, "Failed to load a font! Falling back to default font\n");
+		if (in_game) {
+			Infofnt_set(old_infofnt);
+			plog("Failed to load the font! Falling back to default font.\n");
+			Infofnt_set(td->fnt);
+		} else {
+			fprintf(stderr, "Failed to load the font! Falling back to default font.\n");
+		}
 		if (Infofnt_init_data(x11_terms_font_default[index]) == -1) {
 			fprintf(stderr, "Failed to load a default font\n");
 			return(1);

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -573,7 +573,7 @@ static errr Infowin_init_data(Window dad, int x, int y, int w, int h, unsigned i
 	/* Create the Window. */
 	xid = XCreateSimpleWindow(Metadpy->dpy, dad, x, y, w, h, b, b_color, bg_color);
 	if (xid == 0) {
-		printf("Error creating window on display: %s\n", Metadpy->name);
+		fprintf(stderr, "Error creating window on display: %s\n", Metadpy->name);
 		return(1);
 	}
 
@@ -1830,7 +1830,7 @@ static void Term_nuke_x11(term *t) {
 
 	int term_idx = term_data_to_term_idx(td);
 	if (term_idx < 0) {
-		printf("Error getting terminal index from term_data\n");
+		fprintf(stderr, "Error getting terminal index from term_data\n");
 		return;
 	}
 
@@ -2699,12 +2699,12 @@ static int term_data_to_term_idx(term_data *td) {
  */
 static errr x11_term_init(int term_id) {
 	if (term_id < 0 || term_id >= ANGBAND_TERM_MAX) {
-		printf("Terminal index %d out of bounds\n", term_id);
+		fprintf(stderr, "Terminal index %d out of bounds\n", term_id);
 		return(1);
 	}
 
 	if (ang_term[term_id]) {
-		printf("Terminal window with index %d is already initialized\n", term_id);
+		fprintf(stderr, "Terminal window with index %d is already initialized\n", term_id);
 		/* Success. */
 		return(0);
 	}
@@ -2726,7 +2726,7 @@ static errr x11_term_init(int term_id) {
 	}
 
 	if (err) {
-		printf("Error initializing term_data for X11 terminal with index %d\n", term_id);
+		fprintf(stderr, "Error initializing term_data for X11 terminal with index %d\n", term_id);
 		if (ang_term[term_id]) {
 			term_nuke(ang_term[term_id]);
 			ang_term[term_id] = NULL;
@@ -2791,12 +2791,12 @@ errr init_x11(void) {
 
 		/* Check for tiles string & extract tiles width & height. */
 		if (2 != sscanf(graphic_tiles, "%dx%d", &graphics_tile_wid, &graphics_tile_hgt)) {
-			printf("Couldn't extract tile dimensions from: %s\n", graphic_tiles);
+			fprintf(stderr, "Couldn't extract tile dimensions from: %s\n", graphic_tiles);
 			quit("Graphics load error");
 		}
 
 		if (graphics_tile_wid <= 0 || graphics_tile_hgt <= 0) {
-			printf("Invalid tiles dimensions: %dx%d\n", graphics_tile_wid, graphics_tile_hgt);
+			fprintf(stderr, "Invalid tiles dimensions: %dx%d\n", graphics_tile_wid, graphics_tile_hgt);
 			quit("Graphics load error");
 		}
 
@@ -2818,15 +2818,15 @@ errr init_x11(void) {
 		char *data = NULL;
 		errr rerr = 0;
 		if (0 != (rerr = ReadBMPData(filename, &data, &width, &height))) {
-			printf("Graphics file \"%s\" ", filename);
+			fprintf(stderr, "Graphics file \"%s\" ", filename);
 			switch (rerr) {
-				case ReadBMPNoFile:                   printf("can not be read.\n"); break;
-				case ReadBMPReadErrorOrUnexpectedEOF: printf("read error or unexpected end.\n"); break;
-				case ReadBMPInvalidFile:              printf("has incorrect BMP file format.\n"); break;
-				case ReadBMPNoImageData:              printf("contains no image data.\n"); break;
-				case ReadBMPUnexpectedEOF:            printf("unexpected end.\n"); break;
-				case ReadBMPIllegalBitCount:          printf("has illegal bit count, only 24bit and 32bit images are allowed.\n"); break;
-				default: printf("unexpected error.\n");
+				case ReadBMPNoFile:                   fprintf(stderr, "can not be read.\n"); break;
+				case ReadBMPReadErrorOrUnexpectedEOF: fprintf(stderr, "read error or unexpected end.\n"); break;
+				case ReadBMPInvalidFile:              fprintf(stderr, "has incorrect BMP file format.\n"); break;
+				case ReadBMPNoImageData:              fprintf(stderr, "contains no image data.\n"); break;
+				case ReadBMPUnexpectedEOF:            fprintf(stderr, "unexpected end.\n"); break;
+				case ReadBMPIllegalBitCount:          fprintf(stderr, "has illegal bit count, only 24bit and 32bit images are allowed.\n"); break;
+				default: fprintf(stderr, "unexpected error.\n");
 			}
 			quit("Graphics load error");
 		}
@@ -2834,7 +2834,7 @@ errr init_x11(void) {
 		/* Calculate tiles per row. */
 		graphics_image_tpr = width / graphics_tile_wid;
 		if (graphics_image_tpr <= 0) { /* Paranoia. */
-			printf("Invalid image tiles per row count: %d\n", graphics_image_tpr);
+			fprintf(stderr, "Invalid image tiles per row count: %d\n", graphics_image_tpr);
 			quit("Graphics load error");
 		}
 
@@ -2866,7 +2866,7 @@ errr init_x11(void) {
 		/* Main window is always visible, all other depend on configuration. */
 		if (i == 0 || term_prefs[i].visible) {
 			if (x11_term_init(i) != 0) {
-				printf("Error initializing X11 terminal window with index %d\n", i);
+				fprintf(stderr, "Error initializing X11 terminal window with index %d\n", i);
 				if (i == 0) {
 					/* Can't run without main screen. */
 					return(1);
@@ -3151,7 +3151,6 @@ void resize_window_x11(int term_idx, int cols, int rows) {
 
 	/* Clear timer. */
 	if (td->resize_timer.tv_sec > 0 || td->resize_timer.tv_nsec > 0) {
-		printf("Clear timer\n");
 		td->resize_timer.tv_sec=0;
 		td->resize_timer.tv_nsec=0;
 	}
@@ -3279,7 +3278,7 @@ void set_font_name(int term_idx, char* fnt) {
 
 void term_toggle_visibility(int term_idx) {
 	if (term_idx == 0) {
-		printf("Warning: Toggling visibility for main terminal window is not allowed\n");
+		fprintf(stderr, "Warning: Toggling visibility for main terminal window is not allowed\n");
 		return;
 	}
 
@@ -3303,7 +3302,7 @@ void term_toggle_visibility(int term_idx) {
 	Term_activate(&screen.t);
 
 	if (err) {
-		printf("Error initializing toggled X11 terminal window with index %d\n", term_idx);
+		fprintf(stderr, "Error initializing toggled X11 terminal window with index %d\n", term_idx);
 		return;
 	}
 	/* Window was successfully created. */

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -3203,7 +3203,8 @@ bool ask_for_bigmap(void) {
 const char* get_font_name(int term_idx) {
 	term_data *td = term_idx_to_term_data(term_idx);
 	if (td->fnt) return td->fnt->name;
-	else return DEFAULT_X11_FONT;
+	if (strlen(term_prefs[term_idx].font)) return term_prefs[term_idx].font;
+	return DEFAULT_X11_FONT;
 }
 
 void set_font_name(int term_idx, char* fnt) {

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -3240,8 +3240,8 @@ void term_toggle_visibility(int term_idx) {
 	Term_activate(&screen.t);
 	Infowin_set(screen.outer);
 
-	/* Redraw all windows. */
-	cmd_redraw();
+	/* Mark all windows for content refresh. */
+	p_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER | PW_MSGNOCHAT | PW_MESSAGE | PW_CHAT | PW_MINIMAP);//PW_LAGOMETER is called automatically, no need.
 }
 
 /* Returns true if terminal window specified by term_idx is currently visible. */

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -2389,7 +2389,7 @@ static errr term_data_init(int index, term_data *td, bool fixed, cptr name, cptr
 	Infofnt_set(td->fnt);
 	if (Infofnt_init_data(font) == -1) {
 		/* Initialization failed, log and try to use the default font. */
-		fprintf(stderr, "Failed to load the \"%s\" font for terminal %d! Falling back to default font.\n", font, index);
+		fprintf(stderr, "Failed to load the \"%s\" font for terminal %d\n", font, index);
 		if (in_game) {
 			/* If in game, inform the user. */
 			Infofnt_set(old_infofnt);

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -3252,6 +3252,16 @@ void set_font_name(int term_idx, char* fnt) {
 		fprintf(stderr, "Terminal index %d is out of bounds for set_font_name\n", term_idx);
 		return;
 	}
+
+	if (!term_get_visibility(term_idx)) {
+		/* Terminal is not visible, Do nothing, just change the font name in preferences. */
+		if (strcmp(term_prefs[term_idx].font, fnt) != 0) {
+			strncpy(term_prefs[term_idx].font, fnt, sizeof(term_prefs[term_idx].font));
+			term_prefs[term_idx].font[sizeof(term_prefs[term_idx].font) - 1] = '\0';
+		}
+		return;
+	}
+
 	term_force_font(term_idx, fnt);
 
 	/* Redraw the terminal for which the font was forced. */

--- a/src/client/main-x11.c
+++ b/src/client/main-x11.c
@@ -2704,7 +2704,7 @@ static errr x11_term_init(int term_id) {
 	/* Store created terminal with X11 term data to ang_term array, even if term_data_init failed. */
 	ang_term[term_id] = Term;
 
-	if (err != 0) {
+	if (err) {
 		printf("Error initializing term_data for X11 terminal with index %d\n", term_id);
 		term_nuke(ang_term[term_id]);
 		ang_term[term_id] = NULL;
@@ -3217,7 +3217,7 @@ void term_toggle_visibility(int term_idx) {
 	}
 
 	if (term_get_visibility(term_idx)) {
-		/* Window is visible, save it, close it and free its resources. */
+		/* Window is visible. Save it, close it and free its resources. */
 
 		/* Save window position, dimension and font to term_prefs, cause at quitting the nuke_hook won't be called for closed windows. */
 		term_data_to_term_prefs(term_idx);
@@ -3228,17 +3228,19 @@ void term_toggle_visibility(int term_idx) {
 		ang_term[term_idx] = NULL;
 		return;
 	}
+	/* Window is not visible. Create it and draw content. */
 
 	/* Create and initialize terminal window. */
-	if (x11_term_init(term_idx)) {
+	errr err = x11_term_init(term_idx);
+	/* After initializing the new window is active. Switch to main window. */
+	Term_activate(&screen.t);
+
+	if (err) {
 		printf("Error initializing x11 terminal window with index %d\n", term_idx);
 		return;
 	}
+	/* Window was successfully created. */
 	term_prefs[term_idx].visible = true;
-
-	/* After initializing the new window is active. Switch to main window. */
-	Term_activate(&screen.t);
-	Infowin_set(screen.outer);
 
 	/* Mark all windows for content refresh. */
 	p_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER | PW_MSGNOCHAT | PW_MESSAGE | PW_CHAT | PW_MINIMAP);//PW_LAGOMETER is called automatically, no need.

--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -1373,7 +1373,11 @@ int Net_start(int sex, int race, int class) {
 	get_screen_font_name(fname);
 
 	if (is_atleast(&server_version, 4, 8, 1, 2, 0, 0))
+#ifdef USE_GRAPHICS
 		Packet_printf(&wbuf, "%hd%hd%hd%hd%hd%hd%hd%s%s", sex, race, class, trait, audio_sfx, audio_music, use_graphics, graphic_tiles, fname);
+#else
+		Packet_printf(&wbuf, "%hd%hd%hd%hd%hd%hd%hd%s%s", sex, race, class, trait, audio_sfx, audio_music, use_graphics, "NO_GRAPHICS", fname);
+#endif
 	else if (is_newer_than(&server_version, 4, 4, 5, 10, 0, 0))
 		Packet_printf(&wbuf, "%hd%hd%hd%hd%hd%hd", sex, race, class, trait, audio_sfx, audio_music);
 	else Packet_printf(&wbuf, "%hd%hd%hd", sex, race, class);
@@ -6912,7 +6916,11 @@ int Send_font(void) {
 	//td->font_wid; td->font_hgt;
 
 	get_screen_font_name(fname);
+#ifdef USE_GRAPHICS
 	if ((n = Packet_printf(&wbuf, "%c%hd%s%s", PKT_FONT, use_graphics, graphic_tiles, fname)) <= 0) return n;
+#else
+	if ((n = Packet_printf(&wbuf, "%c%hd%s%s", PKT_FONT, use_graphics, "NO_GRAPHICS", fname)) <= 0) return n;
+#endif
 	return(1);
 }
 

--- a/src/client/z-term.c
+++ b/src/client/z-term.c
@@ -36,7 +36,7 @@ void (*resize_main_window)(int cols, int rows);
  *
  * This package was designed to help port the game "Angband" to a wide
  * variety of different platforms.  Angband, like many other games in
- * the "rogue-like" heirarchy, requires, at the minimum, the ability
+ * the "rogue-like" hierarchy, requires, at the minimum, the ability
  * to display "colored textual symbols" in a standard 80x24 "window",
  * such as that provided by most dumb terminals, and many old personal
  * computers, and to check for "keypresses" from the user.  The major
@@ -77,7 +77,7 @@ void (*resize_main_window)(int cols, int rows);
  *
  *
  * This package provides support for multiple windows, each of an
- * arbitrary size (up to 255x255), each with its own set of flags,
+ * arbitrary size, each with its own set of flags,
  * and its own hooks to handle several low-level procedures which
  * differ from platform to platform.  Then the main program simply
  * creates one or more "term" structures, setting the various flags
@@ -92,15 +92,17 @@ void (*resize_main_window)(int cols, int rows);
  * using flags and hooks appropriate to the given platform, so that
  * the "main()" function can call one (or more) of the "init_xxx()"
  * functions, as appropriate, to prepare the required "term_screen"
- * (and the optional "term_mirror", "term_choice", "term_recall")
- * pointers to "term" structures.  Other "main-xxx.c" systems contain
- * their own "main()" function which, in addition to doing everything
- * needed to initialize the actual program, also does everything that
- * the normal "init_xxx()" functions would do.
+ * (and the optional "term_mirror", "term_choice", "term_recall" and
+ * term_term_4 to term_term_7) pointers to "term" structures.  Other
+ * "main-xxx.c" systems contain their own "main()" function which,
+ * in addition to doing everything, needed to initialize the actual
+ * program, also does everything that the normal "init_xxx()" functions
+ * would do.
  *
  *
  * This package allows each "grid" in each window to hold an attr/char
- * pair, with each ranging from 0 to 255, and makes very few assumptions
+ * pair, with each ranging from 0 to 255 (The char can hold bigger values.
+ * See the "Edit 2020" paragraph bellow), and makes very few assumptions
  * about the meaning of any attr/char values.  Normally, we assume that
  * "attr 0" is "black", with the semantics that "black" text should be
  * sent to "Term_wipe()" instead of "Term_text()", but this behavior is
@@ -146,7 +148,7 @@ void (*resize_main_window)(int cols, int rows);
  * "term" to be initialized or destroyed, and which allow this package,
  * or a program, to access the special "hooks" defined for the current
  * "term", and a set of functions which those "hooks" can use to inform
- * this package of the results of certain occurances, for example, one
+ * this package of the results of certain occurrences, for example, one
  * such function allows this package to learn about user keypresses,
  * detected by one of the special "hooks".
  *


### PR DESCRIPTION
This PR brings a few features to X11 client font options in-game menu and fixes some crashes here and there.

- In the font menu you can now toggle windows visibility without the need of the program restart.
- In the font menu the program does not crash when entering bad font.
- In the font menu window redraws are fixed when changing fonts.
- In the font menu you can now cycle up a font with the "=" key.
- During client start, if the font from rc file load fails, don't crash, but fall back to default font and if that fails, fall back to ncurses client.
- When exiting during login or during start of ncurses client, restore terminal modes and cursor.