### PR TITLE
Add SDL2 support to the OSX makefile, and make it the default option.

### DIFF
--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -169,9 +169,9 @@ X11BASE = /opt/X11
 ## Variant for x11+ncurses (gcu)
 ##
 ## With SDL
-CFLAGS = -O2 -g -pipe -Wall -DOSX -DUSE_X11 -DUSE_GCU -I${X11BASE}/include -D_XOPEN_SOURCE -D_BSD_SOURCE -DMEXP=19937 -std=c99 -DNCURSES_OPAQUE=0 -DSOUND_SDL `sdl-config --cflags` -DACC32
-LIBS = -lX11 -lncurses -lm -lSDL_mixer
-LDFLAGS = -L${X11BASE}/lib -L/usr/local/lib `sdl-config --libs`
+#CFLAGS = -O2 -g -pipe -Wall -DOSX -DUSE_X11 -DUSE_GCU -I${X11BASE}/include -D_XOPEN_SOURCE -D_BSD_SOURCE -DMEXP=19937 -std=c99 -DNCURSES_OPAQUE=0 -DSOUND_SDL `sdl-config --cflags` -DACC32
+#LIBS = -lX11 -lncurses -lm -lSDL_mixer
+#LDFLAGS = -L${X11BASE}/lib -L/usr/local/lib `sdl-config --libs`
 #-lXtst (for numlock - obsolete)
 ## Uncomment this if you want to bundle libraries with the client
 #LDFLAGS += -Wl,-rpath,\$$ORIGIN
@@ -180,6 +180,18 @@ LDFLAGS = -L${X11BASE}/lib -L/usr/local/lib `sdl-config --libs`
 #CFLAGS = -O2 -g -pipe -Wall -DOSX -DUSE_X11 -DUSE_GCU -I${X11BASE}/include -D_XOPEN_SOURCE -D_BSD_SOURCE -DMEXP=19937 -std=c99 -DNCURSES_OPAQUE=0
 #LIBS = -lX11 -lncurses -lm
 #LDFLAGS=-L${X11BASE}/lib -L/usr/local/lib
+
+# With SDL2
+#  With sdl2-config
+CFLAGS = -pipe -Wall -DOSX -DUSE_X11 -DUSE_GCU -I${X11BASE}/include -D_XOPEN_SOURCE -D_BSD_SOURCE -DMEXP=19937 -std=c99 -DNCURSES_OPAQUE=0 -DSOUND_SDL `sdl2-config --cflags` -DACC32
+#  With manually set prefix
+#CFLAGS = -pipe -Wall -DOSX -DUSE_X11 -DUSE_GCU -I${X11BASE}/include -D_XOPEN_SOURCE -D_BSD_SOURCE -DMEXP=19937 -std=c99 -DNCURSES_OPAQUE=0 -DSOUND_SDL -I/usr/local/include/SDL2 -I/usr/include/SDL2 -D_REENTRANT -DACC32
+#  With sdl2-config
+LIBS = -lX11 -lncurses -lm -lSDL2_mixer
+LDFLAGS = -L${X11BASE}/lib -L/usr/local/lib `sdl2-config --libs`
+#  With manually set prefix
+#LIBS = -lX11 -lncurses -lm -lSDL2_mixer
+#LDFLAGS = -L${X11BASE}/lib -L/usr/local/lib -L/usr/lib -pthread -lSDL2
 
 
 ##


### PR DESCRIPTION
These are changes I had to make to the OSX makefile to get TomeNET to build with code containing SDL2 dependencies. This SDL2 section was written purely by analogy with the SDL section of the same file, and the SDL and SDL2 sections of the primary makefile.