### PR TITLE
Ammo break chance display reflects skill

### DIFF
--- a/src/server/externs.h
+++ b/src/server/externs.h
@@ -1308,7 +1308,7 @@ extern void discharge_rod(object_type *o_ptr, int c);
 extern s32b unique_quark;
 extern void object_copy(object_type *o_ptr, object_type *j_ptr);
 extern void object_wipe(object_type *o_ptr);
-extern int breakage_chance_with_skill(int Ind, object_type *o_ptr, int *permille);
+extern int breakage_chance_with_skill(int Ind, object_type *o_ptr, byte *permille);
 extern int get_archery_skill_from_ammo(object_type *o_ptr);
 extern bool can_use(int Ind, object_type *o_ptr);
 extern bool can_use_verbose(int Ind, object_type *o_ptr);

--- a/src/server/externs.h
+++ b/src/server/externs.h
@@ -1308,6 +1308,8 @@ extern void discharge_rod(object_type *o_ptr, int c);
 extern s32b unique_quark;
 extern void object_copy(object_type *o_ptr, object_type *j_ptr);
 extern void object_wipe(object_type *o_ptr);
+extern int breakage_chance_with_skill(int Ind, object_type *o_ptr, int *permille);
+extern int get_archery_skill_from_ammo(object_type *o_ptr);
 extern bool can_use(int Ind, object_type *o_ptr);
 extern bool can_use_verbose(int Ind, object_type *o_ptr);
 extern bool can_use_admin(int Ind, object_type *o_ptr);

--- a/src/server/object1.c
+++ b/src/server/object1.c
@@ -5329,10 +5329,11 @@ bool identify_combo_aux(int Ind, object_type *o_ptr, bool full, int slot, int In
 #if 1 /* display breakage for ammo and trigger chance for magic devices even if not *id*ed? */
 		if (eff_full) {
 			if (wield_slot(0, o_ptr) == INVEN_AMMO) {
-				byte chance, permille;
+				byte chance, permille, vowel;
 				chance = breakage_chance_with_skill(pt_ptr->Ind, o_ptr, &permille);
-				if (permille == 0) fprintf(fff, "\377WIt has a %d%% chance to break upon hit///.\n", chance);
-				else fprintf(fff, "\377WIt has a %d.%d%% chance to break upon hit///.\n", chance, permille);
+				vowel = (chance == 8) || (chance == 11) || (chance == 18); /* 1 <= chance <= 20 */
+				if (permille == 0) fprintf(fff, "\377WIt has a%s %d%% chance to break upon hit///.\n", vowel ? "n" : "", chance);
+				else fprintf(fff, "\377WIt has a%s %d.%d%% chance to break upon hit///.\n", vowel ? "n" : "", chance, permille);
 			}
 
  #if 1 /* display trigger chance for magic devices? */
@@ -5991,7 +5992,7 @@ bool identify_combo_aux(int Ind, object_type *o_ptr, bool full, int slot, int In
 	if (eff_full && wield_slot(0, o_ptr) == INVEN_AMMO) {
 		u32b shooter_f1 = 0, dummy;
 		object_type *x_ptr = &pt_ptr->inventory[INVEN_BOW];
-		byte chance, permille;
+		byte chance, permille, vowel;
 
 		if (x_ptr->k_idx && x_ptr->tval == TV_BOW &&
 		    (((x_ptr->sval == SV_SHORT_BOW || x_ptr->sval == SV_LONG_BOW) && o_ptr->tval == TV_ARROW) ||
@@ -6024,8 +6025,9 @@ bool identify_combo_aux(int Ind, object_type *o_ptr, bool full, int slot, int In
 		}
 
 		chance = breakage_chance_with_skill(pt_ptr->Ind, o_ptr, &permille);
-		if (permille == 0) fprintf(fff, "\377WIt has a %d%% chance to break upon hit.\n", chance);
-		else fprintf(fff, "\377WIt has a %d.%d%% chance to break upon hit.\n", chance, permille);
+		vowel = (chance == 8) || (chance == 11) || (chance == 18);
+		if (permille == 0) fprintf(fff, "\377WIt has a%s %d%% chance to break upon hit.\n", vowel ? "n" : "", chance);
+		else fprintf(fff, "\377WIt has a%s %d.%d%% chance to break upon hit.\n", vowel ? "n" : "", chance, permille);
 
 		/* TODO: 3rd party observe via Ind_target */
 		display_ammo_damage(Ind_target ? Ind_target : Ind, &forge, fff, f1, shooter_f1);

--- a/src/server/object1.c
+++ b/src/server/object1.c
@@ -6740,7 +6740,7 @@ void display_invenequip(int Ind) {
 }
 
 /* Computes ammo breakage chance after skill has been factored in. */
-int breakage_chance_with_skill(int Ind, object_type *o_ptr, int *permille) {
+int breakage_chance_with_skill(int Ind, object_type *o_ptr, byte *permille) {
 	if (wield_slot(0, o_ptr) != INVEN_AMMO) return -1;
 
 	player_type *p_ptr = Players[Ind];

--- a/src/server/object1.c
+++ b/src/server/object1.c
@@ -5331,7 +5331,7 @@ bool identify_combo_aux(int Ind, object_type *o_ptr, bool full, int slot, int In
 			if (wield_slot(0, o_ptr) == INVEN_AMMO) {
 				byte chance, permille, vowel;
 				chance = breakage_chance_with_skill(pt_ptr->Ind, o_ptr, &permille);
-				vowel = (chance == 8) || (chance == 11) || (chance == 18); /* 1 <= chance <= 20 */
+				vowel = (chance == 8) || (chance == 11) || (chance == 18); /* 0 <= chance <= 20 */
 				if (permille == 0) fprintf(fff, "\377WIt has a%s %d%% chance to break upon hit///.\n", vowel ? "n" : "", chance);
 				else fprintf(fff, "\377WIt has a%s %d.%d%% chance to break upon hit///.\n", vowel ? "n" : "", chance, permille);
 			}


### PR DESCRIPTION
This is my most involved feature yet. Where before the Inspect (shift+I) screen for a piece of ammo might say
> `It has 20% chances to break upon hit.`

this feature is designed to allow the breakage chance displayed here to depend on the relevant ranged skill of the player, such that it might read
> `It has an 8.3% chance to break upon hit.`

I also changed the phrasing to read more naturally, including vowel handling (a/an). It's possible a function that takes a number and outputs whether it starts with a vowel for a/an purposes (e.g. "an 8% chance" vs. "a 7% chance") might be useful to have over in utils.c, alongside the existing is_a_vowel function.

Anyway, I was also unsure of where to put the function declaration. I stuck it in externs.h as a first guess, even though it isn't called externally, since there wasn't an object1.h for it to go in, but I wanted to consult about the *right* approach to take.