### PR TITLE
Graphics: flickering fix

### DIFF
--- a/src/server/cave.c
+++ b/src/server/cave.c
@@ -1910,15 +1910,6 @@ static void get_monster_color(int Ind, monster_type *m_ptr, monster_race *r_ptr,
 		(*ap) = a;
 	}
 
-	/* Special attr/char codes */
-	else if ((a & 0x80) && (c & 0x80)) {
-		/* Use char */
-		(*cp) = c;
-
-		/* Use attr */
-		(*ap) = a;
-	}
-
 #ifdef M_EGO_NEW_FLICKER
 	/* Hack -- Unique/Ego 'glitters' sometimes */
 	else if ((((r_ptr->flags1 & RF1_UNIQUE) && magik(30)) ||

--- a/src/server/cave.c
+++ b/src/server/cave.c
@@ -1911,7 +1911,7 @@ static void get_monster_color(int Ind, monster_type *m_ptr, monster_race *r_ptr,
 	}
 
 	/* Special attr/char codes */
-	else if (c > MAX_FONT_CHAR) {
+	else if ((a & 0x80) && (c & 0x80)) {
 		/* Use char */
 		(*cp) = c;
 


### PR DESCRIPTION
# Problem

## In game

If a specific moster has graphic tile, in game it looks like: 
- multi-hued dragons, gwops, some demons and 'p's which color is usually flickering displayed in single violet color
- shapechangers displayed in there symbol (like Unmakers, Lord of Chaos, Avatar of Nyarlathotep)

(I will add screenshots or video later)

## How to reproduce

Make graphic tiles for monsters like:
- Lord of Chaos 
- Avatar of Nyarlathotep
- Lord of Change
- Ancient multi-hued dragon
- Sky Drake
- Great Wyrm of Balance
- Great Wyrm of Many Colours
- Great Wyrm of Power

And see how they look with graphics and without it.

You can use my tiles from https://github.com/TomenetGame/tomenet/issues/48

## In code

As is see:

Color flickering(ego, uniques, multi-hued monsters) and char changing(shapechangers, clear monsters) handling is not working for monsters which tiles are remapped in graphics.
That code is from line 1922 to 2087.

Code isn't working because `else if (c > MAX_FONT_CHAR)` placed before that.
I don't know why old `else if ((a & 0x80) && (c & 0x80))` was there. 

I think now that is not correct, as graphics chars are not that special and this code must work for them.

I'm not sure if that is the right fix.