### PR TITLE
Fix key input bug (in CJK IME)

### DIFF
--- a/src/client/main-win.c
+++ b/src/client/main-win.c
@@ -4297,7 +4297,7 @@ int FAR PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, in
 	resize_main_window = resize_main_window_win;
 
 	if (hPrevInst == NULL) {
-		wc.style         = CS_CLASSDC;
+		wc.style         = CS_CLASSDC | CS_IME;
 		wc.lpfnWndProc   = AngbandWndProc;
 		wc.cbClsExtra    = 0;
 		wc.cbWndExtra    = 4; /* one long pointer to term_data */


### PR DESCRIPTION
> The `CS_IME` in the `WNDCLASS` structure is one of the class style flags in Windows, and it controls IME (Input Method Editor) related processing.
The `CS_IME` flag enables a window in Windows to handle IME-related messages when using an IME. IMEs are typically used for inputting multibyte character languages like Japanese, Chinese, or Korean, and they allow users to convert keystrokes into complex characters or symbols while typing on the keyboard.
In other words, setting the `CS_IME` flag makes the corresponding window class function as an IME-aware window, allowing it to efficiently handle IME-related message processing and manage state transitions when IME functionality is required.

Add `CS_IME` flag to `WNDCLASS` object to fix key input bug.
```
Windows 11 + Korean IME
 - Key input is possible before entering the world.
 - After entering the world, certain keys (such as alphabets and numbers) become unresponsive (arrow keys still function).
```
Video of this problem: https://www.youtube.com/watch?v=U3lCvgIMvuQ

Client: [TomeNET-4.9.2-IME-BUGFIX-client-withsfx.zip](https://github.com/user-attachments/files/16973870/TomeNET-4.9.2-IME-BUGFIX-client-withsfx.zip)

Related links: 
 - https://stackoverflow.com/questions/33649759/whats-does-cs-ime-style-means-in-the-context-of-registerclass-in-winapi
 - https://learn.microsoft.com/en-us/previous-versions/windows/embedded/aa453922(v=msdn.10)#remarks