### PR TITLE
Restore original floor item stack in auto_stow if magic device isn't stowed

### DIFF
--- a/src/server/cmd1.c
+++ b/src/server/cmd1.c
@@ -1661,7 +1661,7 @@ s16b auto_stow_okay(int Ind, object_type *o_ptr, bool store_bought) {
     If o_stowed_ptr isn't NULL its reference will be set to the resulting stowed object. */
 s16b auto_stow(int Ind, object_type *o_ptr, int o_idx, bool pick_one, bool store_bought, bool quiet, u32b cave_info) {
 	int i, num, slot, globalslot;
-	object_type *s_ptr, forge_one, *o_ptr_tmp = o_ptr;
+	object_type *s_ptr, forge_one, forge_orig, *o_ptr_tmp = o_ptr;
 	player_type *p_ptr = Players[Ind];
 	bool delete_it, fully_stowed = FALSE, stowed_some = FALSE, pick_all = FALSE;
 
@@ -1692,6 +1692,7 @@ s16b auto_stow(int Ind, object_type *o_ptr, int o_idx, bool pick_one, bool store
 
 		/* for pick_one: need to divide wand/staff charges */
 		if (is_magic_device(o_ptr->tval) && num > 1) {
+			forge_orig = *o_ptr;
 			forge_one = *o_ptr;
 			forge_one.number = 1;
 			divide_charged_item(&forge_one, o_ptr, 1);
@@ -1744,8 +1745,10 @@ s16b auto_stow(int Ind, object_type *o_ptr, int o_idx, bool pick_one, bool store
  #endif
 	}
 
-	if (forge_one.tval) o_ptr = o_ptr_tmp;
-	else
+	if (forge_one.tval) {
+		o_ptr = o_ptr_tmp;
+		if (!stowed_some) *o_ptr = forge_orig;
+	} else
 	/* Unhack number */
 	if (pick_one) o_ptr->number += num - 1;
 


### PR DESCRIPTION
When picking up a single magic device with CTRL-G (pick_one), a single item is split to forge_one so that charges can be divided between that item and the items on the ground. If a subinventory slot is found, it tries to stow the item. If it's not stowed, it continues to normal carry() which rereads the already decremented pile and does normal single pickup. So 2 items are deleted but only 1 is picked up

and give me back my 8 Mithril-Plated Rods of Healing