### PR TITLE
Fix pick-one item loss on unid + bag refusal

### DIFF
--- a/src/server/cmd1.c
+++ b/src/server/cmd1.c
@@ -1714,7 +1714,7 @@ s16b auto_stow(int Ind, object_type *o_ptr, int o_idx, bool pick_one, bool store
 		if ((!object_known_p(Ind, o_ptr) || !object_aware_p(Ind, o_ptr))
 		    && check_guard_inscription(s_ptr->note, 'I'))
  #ifdef SUBINVEN_LIMIT_GROUP
-			return(FALSE);
+			break;
  #else
 			continue;
  #endif

--- a/src/server/cmd1.c
+++ b/src/server/cmd1.c
@@ -1709,16 +1709,6 @@ s16b auto_stow(int Ind, object_type *o_ptr, int o_idx, bool pick_one, bool store
 		/* Must fit the object type */
 		if (!item_matches_subinven(Ind, get_subinven_group(s_ptr->sval), o_ptr)) continue;
 
-		/* Player doesn't want to auto-stow unidentified items?
-		   (Note that unidentified rods can never be auto-stowed anyway, as they might be directional.) */
-		if ((!object_known_p(Ind, o_ptr) || !object_aware_p(Ind, o_ptr))
-		    && check_guard_inscription(s_ptr->note, 'I'))
- #ifdef SUBINVEN_LIMIT_GROUP
-			break;
- #else
-			continue;
- #endif
-
 		/* Player disabled auto-stow via bag inscription? */
 		if (!subinven_can_accept(Ind, o_ptr, i, store_bought)) {
  #ifdef SUBINVEN_LIMIT_GROUP

--- a/src/server/cmd3.c
+++ b/src/server/cmd3.c
@@ -5551,7 +5551,7 @@ bool subinven_can_accept(int Ind, object_type *i_ptr, int sslot, bool store_boug
 	object_type *s_ptr = &p_ptr->inventory[sslot], *o_ptr;
 	int i, inum = i_ptr->number, xnum, Gnum, maxG;
 	bool new_stack = FALSE, allow_new_stack = FALSE;
-	int a, o, s;
+	int a, o, s, id;
 
 	/* Player disabled auto-stow via bag inscription? */
 	a = check_guard_inscription(s_ptr->note, 'A');
@@ -5559,6 +5559,13 @@ bool subinven_can_accept(int Ind, object_type *i_ptr, int sslot, bool store_boug
 	if (i_ptr->owner) o = 0; /* Allow again */
 	s = check_guard_inscription(s_ptr->note, 'S');
 	if (store_bought) s = 0; /* Allow again */
+	/* Player doesn't want to auto-stow unidentified items?
+	   (Note that unidentified rods can never be auto-stowed anyway, as they might be directional.) */
+	id = check_guard_inscription(s_ptr->note, 'I');
+	if (object_known_p(Ind, i_ptr) && object_aware_p(Ind, i_ptr)) id = 0;
+
+	/* !I refuses unidentified items outright, no stacking exception */
+	if (id) return(FALSE);
 
 	/* Assume it's not accepted to use multiple 'pure' (without 0/1 parm) !A, !O or !S inscriptions on the same item */
 


### PR DESCRIPTION
The floor stack is already decremented (split into `forge_one`) here for pick_one magic devices. `break` so the post-loop restore runs instead of `return`ing past it and losing the split-off item.